### PR TITLE
Docs and .rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -4,7 +4,7 @@
 # development environment upon cd'ing into the directory
 
 # First we specify our desired <ruby>[@<gemset>], the @gemset name is optional.
-environment_id="ruby-1.9.2-p136@rstatus"
+environment_id="ruby-1.9.2@rstatus"
 
 #
 # First we attempt to load the desired environment directly from the environment

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Running your own
 
 Just do this:
 
-    $ git clone http://github.com/steveklabnik/rstat.us
+    $ git clone https://github.com/hotsh/rstat.us.git
     $ cd rstat.us
     $ heroku create
     $ git push heroku master


### PR DESCRIPTION
.rvmrc no longer depends on ruby patch level, README specifies correct URL to clone
