### PR TITLE
404 page too short

### DIFF
--- a/views/404.haml
+++ b/views/404.haml
@@ -13,6 +13,14 @@
           Oops!
         %h3
           Something went wrong.
-          
+
         %a{:href => "/"}
           Go back to rstat.us
+    /
+      Browsers like Google Chrome and Internet Explorer decide not to display 
+      error pages if the content length of the page is too short.  For Internet Explorer,
+      it appears the magic number is 512 bytes.  To be safe, make sure your error
+      pages are long enough.  This little comment is here to do just that. 
+      Maybe some day there will be a really witty 404 page here.  I'm thinking
+      something along the lines of "rrrrrrgh!  This rstatus page has been 
+      commandeered by pirates."  Okay that should be enough...


### PR DESCRIPTION
Chrome and IE are notorious for not displaying 404s if the pages don't contain enough content.  The current 404 is too short as it stands.  This simply adds a haml html comment to the 404 view to make it long enough to appear in Chrome and IE.

More about this:
http://www.andyjarrett.co.uk/blog/index.cfm/2010/2/21/Google-Chrome-hijacks-404-pages
http://stackoverflow.com/questions/1463156/rails-404-html-is-not-rendered-in-ie
