### PR TITLE
Added hashtag follow support

### DIFF
--- a/rstatus.rb
+++ b/rstatus.rb
@@ -615,6 +615,15 @@ class Rstatus < Sinatra::Base
     haml :external_subscription
   end
 
+  get "/htfollow" do
+    haml :hashtag_subscription
+  end
+
+  post "/htfollow" do
+    @hashtag = params[:tag]
+    redirect "/hashtags/#{@hashtag}"
+  end
+
   get "/contact" do
     haml :contact
   end

--- a/test/rstatus_test.rb
+++ b/test/rstatus_test.rb
@@ -212,6 +212,21 @@ class RstatusTest < MiniTest::Unit::TestCase
 
     assert_equal 404, page.status_code
   end
+  
+  def test_visit_hashtag_follow_form
+    visit "/htfollow"
+    assert_equal 200, page.status_code
+  end
+
+  def test_follow_hashtag_from_form
+    visit "/htfollow"
+    fill_in "tag", :with => "test"
+    click_button "Follow"
+
+    assert_equal 200, page.status_code
+    assert_match /\//, page.current_url
+    assert_match /#test/, page.body
+  end
 
 end
 

--- a/views/_navigation.haml
+++ b/views/_navigation.haml
@@ -1,4 +1,4 @@
-- nav = [{:url => "/", :name => "Timeline"}, {:url => "/replies", :name => "Replies"}]
+- nav = [{:url => "/", :name => "Timeline"}, {:url => "/replies", :name => "Replies"}, {:url => "/htfollow", :name => "+"}]
 - unless @hashtag.nil?
   - nav << {:url => "/hashtags/#{@hashtag}", :name => "##{@hashtag}"}
 #navigation


### PR DESCRIPTION
Added a + symbol next to the Timeline | Replies | World for nav that links to a new route /htfollow. This renders a simple form and posts to /htfollow. I also included some tests.
