### PR TITLE
User browse

### DIFF
--- a/rstatus.rb
+++ b/rstatus.rb
@@ -62,7 +62,7 @@ class Rstatus < Sinatra::Base
   configure :production do
     require 'newrelic_rpm'
   end
-  
+
 
   # We're using [SendGrid](http://sendgrid.com/) to send our emails. It's really
   # easy; the Heroku addon sets us up with environment variables with all of the
@@ -221,6 +221,34 @@ class Rstatus < Sinatra::Base
 
   get '/users/new' do
     haml :"users/new"
+  end
+
+  get '/users' do
+    params[:page] ||= 1
+    params[:per_page] ||= 20
+    params[:page] = params[:page].to_i
+    params[:per_page] = params[:per_page].to_i
+
+    if params[:letter] == "other"
+      @users = User.where(:username => /^[^a-z0-9]/i)
+    elsif params[:letter]
+      @users = User.where(:username => /^#{params[:letter][0]}/i)
+    else
+      @users = User
+    end
+
+    @users = @users.sort(:username).paginate(:page => params[:page], :per_page => params[:per_page])
+
+    @next_page = nil
+    @prev_page = nil
+
+    @next_page = "?#{Rack::Utils.build_query :page => params[:page] + 1}"
+
+    if params[:page] > 1
+      @prev_page = "?#{Rack::Utils.build_query :page => params[:page] - 1}"
+    end
+
+    haml :"users/index"
   end
 
   post '/users' do
@@ -478,16 +506,16 @@ class Rstatus < Sinatra::Base
     params[:page] = params[:page].to_i
     params[:per_page] = params[:per_page].to_i
     feeds = User.first(:username => params[:name]).followers
-    
+
     @users = feeds.paginate(:page => params[:page], :per_page => params[:per_page])
-	
+
     @next_page = nil
     @prev_page = nil
 
     if params[:page]*params[:per_page] < feeds.count
 	  @next_page = "?#{Rack::Utils.build_query :page => params[:page] + 1}"
     end
-    
+
     if params[:page] > 1
 	  @prev_page = "?#{Rack::Utils.build_query :page => params[:page] - 1}"
     end
@@ -512,7 +540,7 @@ class Rstatus < Sinatra::Base
 
   post '/updates' do
     u = Update.new(:text => params[:text],
-                   :referral_id => params[:referral_id], 
+                   :referral_id => params[:referral_id],
                    :author => current_user.author,
                    :oauth_token => session[:oauth_token],
                    :oauth_secret => session[:oauth_secret])
@@ -541,7 +569,7 @@ class Rstatus < Sinatra::Base
   end
 
   post '/signup' do
-    u = User.create(:email => params[:email], 
+    u = User.create(:email => params[:email],
                     :status => "unconfirmed")
     u.set_perishable_token
 

--- a/test/rstatus_test.rb
+++ b/test/rstatus_test.rb
@@ -50,7 +50,7 @@ class RstatusTest < MiniTest::Unit::TestCase
     a = Factory(:authorization, :user => u)
 
     log_in(u, a.uid)
-    
+
     visit "/users/#{u.username}/following"
     assert_match u.username, page.body
   end
@@ -148,7 +148,7 @@ class RstatusTest < MiniTest::Unit::TestCase
   def test_user_following_paginates
     u = Factory(:user)
     a = Factory(:authorization, :user => u)
-    
+
     log_in(u, a.uid)
 
     51.times do
@@ -167,7 +167,7 @@ class RstatusTest < MiniTest::Unit::TestCase
   def test_user_followers_paginates
     u = Factory(:user)
     a = Factory(:authorization, :user => u)
-    
+
     log_in(u, a.uid)
 
     51.times do
@@ -176,7 +176,7 @@ class RstatusTest < MiniTest::Unit::TestCase
     end
 
     visit "/users/#{u.username}/followers"
-    
+
     click_link "next_button"
 
     assert_match "Previous", page.body
@@ -242,5 +242,93 @@ class RstatusTest < MiniTest::Unit::TestCase
     assert_equal 404, page.status_code
   end
 
+  def test_users_browse
+    zebra    = Factory(:user, :username => "zebra")
+    aardvark = Factory(:user, :username => "aardvark")
+    a = Factory(:authorization, :user => aardvark)
+    log_in(aardvark, a.uid)
+
+    visit "/users"
+
+    assert has_link? "aardvark"
+    assert has_link? "zebra"
+  end
+
+  def test_users_browse_paginates
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u)
+
+    log_in(u, a.uid)
+
+    51.times do
+      u2 = Factory(:user)
+    end
+
+    visit "/users"
+
+    click_link "next_button"
+
+    assert_match "Previous", page.body
+    assert_match "Next", page.body
+  end
+
+  def test_users_browse_sorted
+    zebra    = Factory(:user, :username => "zebra")
+    aardvark = Factory(:user, :username => "aardvark")
+    a = Factory(:authorization, :user => aardvark)
+
+    log_in(aardvark, a.uid)
+
+    visit "/users"
+    assert_match /aardvark.*zebra/m, page.body
+  end
+
+  def test_users_browse_by_letter
+    alpha = Factory(:user, :username => "alpha")
+    a = Factory(:authorization, :user => alpha)
+
+    ["apple", "beta", "BANANAS"].each do |u|
+      u2 = Factory(:user, :username => u)
+    end
+
+    log_in(alpha, a.uid)
+
+    visit "/users"
+    click_link "B"
+
+    assert has_link? "beta"
+    assert has_link? "BANANAS"
+    refute_match "apple", page.body
+  end
+
+  def test_users_browse_by_non_letter
+    alpha = Factory(:user, :username => "alpha")
+    a = Factory(:authorization, :user => alpha)
+
+    ["flop", "__FILE__"].each do |u|
+      u2 = Factory(:user, :username => u)
+    end
+
+    log_in(alpha, a.uid)
+
+    visit "/users"
+    click_link "other"
+
+    assert has_link? "__FILE__"
+    refute_match "flop", page.body
+  end
+
+  def test_users_browse_no_results
+    alpha = Factory(:user, :username => "alpha")
+    a = Factory(:authorization, :user => alpha)
+
+    log_in(alpha, a.uid)
+
+    visit "/users"
+    click_link "B"
+
+    assert_match "Sorry, no users that match.", page.body
+
+  end
 end
 

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -25,7 +25,7 @@
                     %a{ :href => "/users/#{current_user.username}/following"}
                       #{current_user.following.length}
                   .followers
-                    Followers: 
+                    Followers:
                     %a{ :href => "/users/#{current_user.username}/followers"}
                       #{current_user.followers.length}
                   .updates
@@ -33,6 +33,9 @@
 
           .links
             %a{:href => "/follow"} Would you like to follow someone not on rstat.us?
+
+          .links
+            %a{:href => "/users"} Browse rstat.us users
 
           .links
             %a{:href => "/feeds/#{current_user.feed.id}.atom"} Atom
@@ -49,6 +52,6 @@
             #flash
               = flash[:notice]
 
-          != yield 
+          != yield
 
     != haml :footer

--- a/views/users/index.haml
+++ b/views/users/index.haml
@@ -1,0 +1,37 @@
+%h1 Browse users
+%div#browse-navigation
+  - "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".each_char do |c|
+    %a{:href => "/users?#{Rack::Utils.build_query :letter => c}"}
+      = c
+  %a{:href => "/users?#{Rack::Utils.build_query :letter => "other"}"}
+    other
+%ul.user-list
+  - if @users.empty?
+    %li
+      Sorry, no users that match.
+
+  - @users.each_with_index do |user, i|
+    %li.user{:class => i%2 == 0 ? "even" : "odd"}
+      -user_url = "/users/#{user.author.username}"
+      .avatar
+        %a{:href => user_url}
+          %img{:alt => "avatar", :src => user.author.avatar_url}/
+
+      .name
+        %a{:href => user_url}
+          %b
+            = user.author.name
+          %br
+          (#{user.author.username})
+
+%nav.pagination
+  - unless @prev_page.nil?
+    %a.button{:href => @prev_page, :id => "prev_button"}
+      &laquo; Previous
+
+  - unless @next_page.nil?
+    %a.button{:href => @next_page, :id => "next_button"}
+      Next &raquo;
+
+- content_for :javascript do
+  %script{:src=>"/js/users.js"}


### PR DESCRIPTION
This adds a browse users to the sidebar, and you can paginate through or choose a letter, number, or "other" to view just the usernames starting with that. Doesn't completely satisfy #24 since that was for search, but browse was mentioned, and frankly I don't know who all is on rstat.us yet so i'm not going to search for everyone and their mother.

Please feel free to suggest and/or make any changes or improvements to this!!
