### PR TITLE
In login / logout

### DIFF
--- a/rstatus.rb
+++ b/rstatus.rb
@@ -589,7 +589,11 @@ class Rstatus < Sinatra::Base
   end
 
   get "/login" do
-    haml :"login"
+    if logged_in?
+      redirect '/'
+    else
+      haml :"login"
+    end
   end
 
   post "/login" do


### PR DESCRIPTION
When not logged in, removes the notice from "/logout" and redirects to "/" in "/login".
