### PR TITLE
Twitter user confirm

### DIFF
--- a/test/rstatus_test.rb
+++ b/test/rstatus_test.rb
@@ -349,5 +349,24 @@ class RstatusTest < MiniTest::Unit::TestCase
     assert_match "Sorry, no users that match.", page.body
 
   end
+  
+  def test_user_signup_twitter
+    Author.any_instance.stubs(:valid_gravatar?).returns(:false)
+    omni_mock("twit")
+    visit '/auth/twitter'
+    
+    assert_match /Confirm account information/, page.body
+    assert_match /\/users\/confirm/, page.current_url
+    
+    fill_in "username", :with => "new_user"
+    fill_in "email", :with => "new_user@email.com"
+    click_button "Finish Signup"
+    
+    u = User.first(:username => "new_user")
+    assert_equal u.nil?, false
+    assert_equal u.email, "new_user@email.com"
+    
+  end  
+  
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,20 +28,24 @@ module TestHelper
   def teardown
     DatabaseCleaner.clean
   end
-
-  def log_in(u, uid = 12345)
-    Author.any_instance.stubs(:valid_gravatar?).returns(:false)
-    OmniAuth.config.add_mock(:twitter, {
+  
+  def omni_mock(username, uid = 12345)
+    return OmniAuth.config.add_mock(:twitter, {
       :uid => uid,
       :user_info => {
         :name => "Joe Public",
-        :nickname => u.username,
+        :nickname => username,
         :urls => { :Website => "http://rstat.us" },
         :description => "A description",
         :image => "/images/something.png"
       },
       :credentials => {:token => "1234", :secret => "4567"}
     })
+  end
+  
+  def log_in(u, uid = 12345)
+    Author.any_instance.stubs(:valid_gravatar?).returns(:false)
+    omni_mock(u.username, uid)
 
     visit '/auth/twitter'
   end

--- a/views/users/confirm.haml
+++ b/views/users/confirm.haml
@@ -1,0 +1,12 @@
+%h2 Confirm account information
+
+%p You are one step away from your new rstat.us account. Make sure you have the right username, provide an email address and you are all set.
+
+%form{:action => "/users", :method => "POST"}
+  %label{:for => "username" } Username: 
+  %input{:type => "text", :name => "username", :id => "username"}
+  %br/
+  %label{:for => "email" } Email: 
+  %input{:type => "text", :name => "email", :id => "email"}
+  %br/
+  %input{:type => "submit", :value => "Finish Signup"}

--- a/views/users/new.haml
+++ b/views/users/new.haml
@@ -3,7 +3,7 @@
 %p Hey, we're sorry about this, but someone already has your username. Mind picking a new one?
 
 %form{:action => "/users", :method => "POST"}
-  Username: 
-  %input{:type => "text", :name => "username"}
+  %label{:for => "username"} Username: 
+  %input{:type => "text", :name => "username", :id => "username"}
   %br/
   %input{:type => "submit", :value => "Finish Signup"}


### PR DESCRIPTION
Added confirmation screen after new users login for facebook/twitter to allow for selection of a new username and entry of an email address
