### PR TITLE
suppress crossposting of @replies to Twitter

### DIFF
--- a/models/update.rb
+++ b/models/update.rb
@@ -71,6 +71,11 @@ class Update
 
   def tweet
     return unless ENV['RACK_ENV'] == 'production'
+    
+    # suppress crossposting of @replies
+    if text[0] == '@'
+      return
+    end
 
     begin
       Twitter.configure do |config|


### PR DESCRIPTION
This is more consistent with expected behavior (i.e. Facebook to Twitter app) and solves the problems we're currently having with @replies to users who don't have Twitter accounts, don't have the same username on Twitter, etc.  Eventually we can make this a setting (and maybe come up with some fancier ways to solve the above problems), but for now, it should be off by default.
