### PR TITLE
Fixed issue with twitter/facebook account auth 

### DIFF
--- a/rstatus.rb
+++ b/rstatus.rb
@@ -228,25 +228,10 @@ class Rstatus < Sinatra::Base
   get '/auth/:provider/callback' do
     auth = request.env['omniauth.auth']
     unless @auth = Authorization.find_from_hash(auth)
-      session[:uid] = auth['uid']
-      session[:provider] = auth['provider']
-      session[:name] = auth['user_info']['name']
-      session[:nickname] = auth['user_info']['nickname']
-      session[:website] = auth['user_info']['urls']['Website']
-      session[:description] = auth['user_info']['description']
-      session[:image] = auth['user_info']['image']
-      #let's store their oauth stuff so they don't have to re-login after
-      session[:oauth_token] = auth['credentials']['token']
-      session[:oauth_secret] = auth['credentials']['secret']
-
-      ## We can probably get rid of this since the user confirmation will check for duplicate usernames [brimil01]
-      if User.first :username => auth['user_info']['nickname'] or auth['user_info']['nickname'] =~ /profile[.]php[?]id=/
-        #we have a username conflict!
-      
-        #let's store their oauth stuff so they don't have to re-login after
-        session[:oauth_token] = auth['credentials']['token']
-        session[:oauth_secret] = auth['credentials']['secret']
-      
+      if logged_in?
+        Authorization.create_from_hash(auth, uri("/"), current_user)
+        redirect "/users/#{current_user.username}/edit"
+      else
         session[:uid] = auth['uid']
         session[:provider] = auth['provider']
         session[:name] = auth['user_info']['name']
@@ -255,14 +240,22 @@ class Rstatus < Sinatra::Base
         session[:description] = auth['user_info']['description']
         session[:image] = auth['user_info']['image']
         session[:email] = auth['user_info']['email']
+        #let's store their oauth stuff so they don't have to re-login after
+        session[:oauth_token] = auth['credentials']['token']
+        session[:oauth_secret] = auth['credentials']['secret']
+        
+        ## We can probably get rid of this since the user confirmation will check for duplicate usernames [brimil01]
+        if User.first :username => auth['user_info']['nickname'] or auth['user_info']['nickname'] =~ /profile[.]php[?]id=/
+          #we have a username conflict!
       
-        flash[:notice] = "Sorry, someone has that name."
-        redirect '/users/new'
-        return
-      else
-        # Redirect to confirm page to verify username and provide email
-        redirect '/users/confirm'
-        return
+          flash[:notice] = "Sorry, someone has that name."
+          redirect '/users/new'
+          return
+        else
+          # Redirect to confirm page to verify username and provide email
+          redirect '/users/confirm'
+          return
+        end
       end
     end
     
@@ -274,14 +267,10 @@ class Rstatus < Sinatra::Base
       @auth.save
     end
 
-    if logged_in?
-      redirect "/users/#{current_user.username}edit"
-    else
-      session[:user_id] = @auth.user.id
+    session[:user_id] = @auth.user.id
 
-      flash[:notice] = "You're now logged in."
-      redirect '/'      
-    end
+    flash[:notice] = "You're now logged in."
+    redirect '/'      
   end
 
   get '/auth/failure' do

--- a/test/rstatus_test.rb
+++ b/test/rstatus_test.rb
@@ -248,12 +248,12 @@ class RstatusTest < MiniTest::Unit::TestCase
 
     assert_match page.body, /#{bio_text}/
   end
-  
+
   def test_user_update_profile_twitter_button
     u = Factory(:user)
     log_in_email(u)
     visit "/users/#{u.username}/edit"
-
+  
     assert_match page.body, /Add Twitter Account/
   end
   
@@ -261,7 +261,7 @@ class RstatusTest < MiniTest::Unit::TestCase
     u = Factory(:user)
     log_in_email(u)
     visit "/users/#{u.username}/edit"
-
+  
     assert_match page.body, /Add Facebook Account/
   end
   
@@ -270,7 +270,7 @@ class RstatusTest < MiniTest::Unit::TestCase
     a = Factory(:authorization, :user => u, :nickname => "Awesomeo the Great")
     log_in(u, a.uid)
     visit "/users/#{u.username}/edit"
-
+  
     assert_match page.body, /Awesomeo the Great/
   end
   
@@ -279,8 +279,191 @@ class RstatusTest < MiniTest::Unit::TestCase
     a = Factory(:authorization, :user => u, :provider => "facebook", :nickname => "Awesomeo the Great")
     log_in_fb(u, a.uid)
     visit "/users/#{u.username}/edit"
-    
+  
     assert_match page.body, /Awesomeo the Great/
+  end
+  
+  def no_twitter_login
+    u = Factory(:user)
+    log_in_email(u)
+    assert_match /Login successful/, page.body
+    assert_equal current_user, u
+  end
+  
+  def test_twitter_send_checkbox_present
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u)
+    log_in(u, a.uid)
+  
+    assert_match page.body, /Twitter/
+    assert_equal find_field('tweet').checked?, true
+  end
+  
+  def test_facebook_send_checkbox_present
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u, :provider => "facebook")
+    log_in_fb(u, a.uid)
+  
+    assert_match page.body, /Facebook/
+    assert_equal find_field('facebook').checked?, true
+  end
+  
+  def test_twitter_send
+    update_text = "Test Twitter Text"
+    Twitter.expects(:update)
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u)
+    log_in(u, a.uid)
+  
+    fill_in "text", :with => update_text
+    check("tweet")
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_facebook_send
+    update_text = "Test Facebook Text"
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u, :provider => "facebook")
+    FbGraph::User.expects(:me).returns(mock(:feed! => nil))
+  
+    log_in_fb(u, a.uid)
+  
+    fill_in "text", :with => update_text
+    check("facebook")
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_twitter_and_facebook_send
+    update_text = "Test Facebook and Twitter Text"
+    FbGraph::User.expects(:me).returns(mock(:feed! => nil))    
+    Twitter.expects(:update)
+  
+    u = Factory(:user)
+    Factory(:authorization, :user => u, :provider => "facebook")
+    a = Factory(:authorization, :user => u)
+  
+    log_in(u, a.uid)
+      
+    fill_in "text", :with => update_text
+    check("facebook")
+    check("tweet")
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_twitter_no_send
+    update_text = "Test Twitter Text"
+    Twitter.expects(:update).never
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u)
+    log_in(u, a.uid)
+  
+    fill_in "text", :with => update_text
+    uncheck("tweet")
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_facebook_no_send
+    update_text = "Test Facebook Text"
+    FbGraph::User.expects(:me).never
+    u = Factory(:user)
+    a = Factory(:authorization, :user => u, :provider => "facebook")
+    log_in_fb(u, a.uid)
+  
+    fill_in "text", :with => update_text
+    uncheck("facebook")
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_no_twitter_no_send
+    update_text = "Test Twitter Text"
+    Twitter.expects(:update).never
+    u = Factory(:user)
+    log_in_email(u)
+      
+    fill_in "text", :with => update_text
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+  
+  def test_no_facebook_no_send
+    update_text = "Test Facebook Text"
+    FbGraph::User.expects(:me).never
+    u = Factory(:user)
+    log_in_email(u)
+      
+    fill_in "text", :with => update_text
+    click_button "Share"
+  
+    assert_match /Update created/, page.body
+  end
+
+  def test_add_twitter_to_account
+    u = Factory(:user)
+    OmniAuth.config.add_mock(:twitter, {
+      :uid => "78654",
+      :user_info => {
+        :name => "Joe Public",
+        :nickname => u.username,
+        :urls => { :Website => "http://rstat.us" },
+        :description => "A description",
+        :image => "/images/something.png"
+      },
+      :credentials => {:token => "1111", :secret => "2222"}
+    })
+    log_in_email(u)
+    visit "/users/#{u.username}/edit"
+    click_button "Add Twitter Account"
+  
+    auth = Authorization.first(:provider => "twitter", :uid => 78654)
+    assert_equal "1111", auth.oauth_token
+    assert_equal "2222", auth.oauth_secret
+    assert_match "/users/#{u.username}/edit", page.current_url
+  end
+
+  def test_add_facebook_to_account
+    u = Factory(:user)
+    OmniAuth.config.add_mock(:facebook, {
+      :uid => 78654,
+      :user_info => {
+        :name => "Joe Public",
+        :email => "joe@public.com",
+        :nickname => u.username,
+        :urls => { :Website => "http://rstat.us" },
+        :description => "A description",
+        :image => "/images/something.png"
+      },
+      :credentials => {:token => "1111", :secret => "2222"}
+    })
+    log_in_email(u)
+    visit "/users/#{u.username}/edit"
+    click_button "Add Facebook Account"
+  
+    auth = Authorization.first(:provider => "facebook", :uid => 78654)
+    assert_equal "1111", auth.oauth_token
+    assert_equal "2222", auth.oauth_secret
+    assert_match "/users/#{u.username}/edit", page.current_url
+  end
+
+  def test_facebook_username
+    new_user = Factory.build(:user, :username => 'profile.php?id=12345')
+    log_in_fb(new_user)
+    assert_match /users\/new/, page.current_url, "not on the new user page."
+  
+    fill_in "username", :with => "janepublic"
+    click_button "Finish Signup"
+    assert_match /Thanks! You're all signed up with janepublic for your username./, page.body
+    assert_match /\//, page.current_url
   end
 
   def test_username_clash
@@ -297,185 +480,6 @@ class RstatusTest < MiniTest::Unit::TestCase
     assert_match /Thanks! You're all signed up with nottaken for your username./, page.body
     assert_match /\//, page.current_url
 
-  end
-  
-  def no_twitter_login
-    u = Factory(:user)
-    log_in_email(u)
-    assert_match /Login successful/, page.body
-    assert_equal current_user, u
-  end
-  
-  def test_twitter_send_checkbox_present
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u)
-    log_in(u, a.uid)
-    
-    assert_match page.body, /Twitter/
-    assert_equal find_field('tweet').checked?, true
-  end
-  
-  def test_facebook_send_checkbox_present
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u, :provider => "facebook")
-    log_in_fb(u, a.uid)
-    
-    assert_match page.body, /Facebook/
-    assert_equal find_field('facebook').checked?, true
-  end
-  
-  def test_twitter_send
-    update_text = "Test Twitter Text"
-    Twitter.expects(:update)
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u)
-    log_in(u, a.uid)
-    
-    fill_in "text", :with => update_text
-    check("tweet")
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_facebook_send
-    update_text = "Test Facebook Text"
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u, :provider => "facebook")
-    FbGraph::User.expects(:me).returns(mock(:feed! => nil))
-    
-    log_in_fb(u, a.uid)
-    
-    fill_in "text", :with => update_text
-    check("facebook")
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_twitter_and_facebook_send
-    update_text = "Test Facebook and Twitter Text"
-    FbGraph::User.expects(:me).returns(mock(:feed! => nil))    
-    Twitter.expects(:update)
-    
-    u = Factory(:user)
-    Factory(:authorization, :user => u, :provider => "facebook")
-    a = Factory(:authorization, :user => u)
-    
-    log_in(u, a.uid)
-        
-    fill_in "text", :with => update_text
-    check("facebook")
-    check("tweet")
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_twitter_no_send
-    update_text = "Test Twitter Text"
-    Twitter.expects(:update).never
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u)
-    log_in(u, a.uid)
-    
-    fill_in "text", :with => update_text
-    uncheck("tweet")
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_facebook_no_send
-    update_text = "Test Facebook Text"
-    FbGraph::User.expects(:me).never
-    u = Factory(:user)
-    a = Factory(:authorization, :user => u, :provider => "facebook")
-    log_in_fb(u, a.uid)
-    
-    fill_in "text", :with => update_text
-    uncheck("facebook")
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_no_twitter_no_send
-    update_text = "Test Twitter Text"
-    Twitter.expects(:update).never
-    u = Factory(:user)
-    log_in_email(u)
-        
-    fill_in "text", :with => update_text
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def test_no_facebook_no_send
-    update_text = "Test Facebook Text"
-    FbGraph::User.expects(:me).never
-    u = Factory(:user)
-    log_in_email(u)
-        
-    fill_in "text", :with => update_text
-    click_button "Share"
-    
-    assert_match /Update created/, page.body
-  end
-  
-  def add_twitter_to_account
-    u = Factory(:user)
-    OmniAuth.config.add_mock(:twitter, {
-      :uid => uid,
-      :user_info => {
-        :name => "Joe Public",
-        :nickname => u.username,
-        :urls => { :Website => "http://rstat.us" },
-        :description => "A description",
-        :image => "/images/something.png"
-      },
-      :credentials => {:token => "1234", :secret => "4567"}
-    })
-    log_in_email(u)
-    visit "/users/#{u.username}/edit"
-    click_button "Add Twitter Account"
-    
-    assert_equal "1234", u.twitter.oauth_token
-    assert_equal "4567", u.twitter.oauth_secret
-  end
-  
-  def add_facebook_to_account
-    u = Factory(:user)
-    OmniAuth.config.add_mock(:facebook, {
-      :uid => uid,
-      :user_info => {
-        :name => "Joe Public",
-        :email => "joe@public.com",
-        :nickname => u.username,
-        :urls => { :Website => "http://rstat.us" },
-        :description => "A description",
-        :image => "/images/something.png"
-      },
-      :credentials => {:token => "1234", :secret => "4567"}
-    })
-    log_in_email(u)
-    visit "/users/#{u.username}/edit"
-    click_button "Add Facebook Account"
-    
-    assert_equal "1234", u.twitter.oauth_token
-    assert_equal "4567", u.twitter.oauth_secret
-  end
-
-  def test_facebook_username
-    new_user = Factory.build(:user, :username => 'profile.php?id=12345')
-    log_in_fb(new_user)
-    assert_match /users\/new/, page.current_url, "not on the new user page."
-
-    fill_in "username", :with => "janepublic"
-    click_button "Finish Signup"
-    assert_match /Thanks! You're all signed up with janepublic for your username./, page.body
-    assert_match /\//, page.current_url
   end
 
   def test_junk_username_gives_404

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,11 +29,13 @@ module TestHelper
     DatabaseCleaner.clean
   end
 
-  def omni_mock(username, uid = 12345)
-    return OmniAuth.config.add_mock(:twitter, {
-      :uid => uid,
+  def omni_mock(username, options={})
+    provider = (options[:provider] || :twitter).to_sym
+    return OmniAuth.config.add_mock(provider, {
+      :uid => options[:uid] || 12345,
       :user_info => {
         :name => "Joe Public",
+        :email => "joe@public.com",
         :nickname => username,
         :urls => { :Website => "http://rstat.us" },
         :description => "A description",
@@ -45,24 +47,14 @@ module TestHelper
 
   def log_in(u, uid = 12345)
     Author.any_instance.stubs(:valid_gravatar?).returns(:false)
-    omni_mock(u.username, uid)
+    omni_mock(u.username, {:uid => uid})
 
     visit '/auth/twitter'
   end
   
   def log_in_fb(u, uid = 12345)
-    OmniAuth.config.add_mock(:facebook, {
-      :uid => uid,
-      :user_info => {
-        :name => "Jane Public",
-        :email => "jane@public.com",
-        :nickname => u.username,
-        :urls => { :website => "http://rstat.us" },
-        :description => "a description",
-        :image => "/images/something.png"
-      },
-      :credentials => {:token => "1234", :secret => "4567"}
-    })
+    Author.any_instance.stubs(:valid_gravatar?).returns(:false)
+    omni_mock(u.username, {:uid => uid, :provider => :facebook})
 
     visit '/auth/facebook'
   end


### PR DESCRIPTION
Fixed issue with twitter/facebook account auth being redirected to account confirm before authorization is saved.
