### PR TITLE
Duplicate "whatlanguage" in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem "whatlanguage"
 gem "ruby-stemmer"
 gem "sass"
 gem "compass"
-gem "whatlanguage"
 gem "tzinfo"
 
 group :development, :test do


### PR DESCRIPTION
I don't know if this is actually a problem, but I noticed that there are two instances importing the "whatlanguage" in the Gemfile.
