### PR TITLE
Switched require_relative statements to ensure the proper environment is

### DIFF
--- a/test/acceptance/acceptance_helper.rb
+++ b/test/acceptance/acceptance_helper.rb
@@ -1,7 +1,6 @@
 require 'rack/test'
 require 'vcr'
 
-require_relative '../../rstatus'
 require_relative '../test_helper'
 
 VCR.config do |c|


### PR DESCRIPTION
This will ensure the acceptance tests run in the test environment, even if you run a specific test separately (example: ruby test/acceptance/auth_test.rb --name test_facebook_send)
