### PR TITLE
Email input types to make it easier for mobile/tablet users

### DIFF
--- a/views/users/confirm.haml
+++ b/views/users/confirm.haml
@@ -7,6 +7,6 @@
   %input{:type => "text", :name => "username", :id => "username"}
   %br/
   %label{:for => "email" } Email:
-  %input{:type => "text", :name => "email", :id => "email"}
+  %input{:type => "email", :name => "email", :id => "email"}
   %br/
   %input{:type => "submit", :value => "Finish Signup"}


### PR DESCRIPTION
Adjusted the input type (and the corresponding CSS) for the input box in /users/confirm to give users a better UX on mobile and tablet devices. This stems from when I was registering via an iPad, and got the confirmation input box like so: http://tinypic.com/view.php?pic=mlpo4j&s=7, instead of an email-specific input box. If rstat.us wants to be the simplest, most easy-to-use microblogging system, then little things like this ought to be taken into consideration.
