### PR TITLE
Changed input type for email input box from "text" to "email". This is to

### DIFF
--- a/views/users/confirm.haml
+++ b/views/users/confirm.haml
@@ -7,6 +7,6 @@
   %input{:type => "text", :name => "username", :id => "username"}
   %br/
   %label{:for => "email" } Email:
-  %input{:type => "text", :name => "email", :id => "email"}
+  %input{:type => "email", :name => "email", :id => "email"}
   %br/
   %input{:type => "submit", :value => "Finish Signup"}


### PR DESCRIPTION
Changed input type for email input box from "text" to "email". This is to make the experience better on mobile/tablet devices in particular.
