### PR TITLE
bad carol, bad merge. plucky query has to use .count, not .length, and co

### DIFF
--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -8,23 +8,21 @@ describe User do
 
   describe "#at_replies" do
     it "returns all at_replies for this user" do
-      skip "carol broke this test somehow-- undefined method `length' for Plucky::Query"
       u = User.create(:username => "steve")
       update = Update.create(:text => "@steve oh hai!")
       Update.create(:text => "just some other update")
 
-      assert_equal 1, u.at_replies({}).length
+      assert_equal 1, u.at_replies({}).count
       assert_equal update.id, u.at_replies({}).first.id
     end
 
     it "returns all at_replies for a username containing ." do
-      skip "carol broke this test somehow-- undefined method `length' for Plucky::Query"
       u = Factory.create(:user, :username => "hello.there")
       u1 = Factory.create(:user, :username => "helloothere")
       update = Update.create(:text => "@hello.there how _you_ doin'?")
 
-      assert_equal 1, u.at_replies({}).length
-      assert_equal 0, u1.at_replies({}).length
+      assert_equal 1, u.at_replies({}).count
+      assert_equal 0, u1.at_replies({}).count
     end
   end
 


### PR DESCRIPTION
bad carol, bad merge. plucky query has to use .count, not .length, and commit 762b8a1 had already fixed this then I unfixed it.

This fixes the 2 skipped tests that I introduced; it doesn't fix the one that was just not being run before.
