### PR TITLE
Closes issue #344. Disallows creation of accounts with usernames but with

### DIFF
--- a/controllers/sessions_controller.rb
+++ b/controllers/sessions_controller.rb
@@ -18,13 +18,17 @@ class Rstatus
     u = User.first :username => params[:username]
     if u.nil?
       @user = User.new params
-      if @user.save
-        session[:user_id] = @user.id
-        flash[:notice] = "Thanks for signing up!"
-        redirect "/"
-      else
-        haml :"login"
+      if @user.valid?
+        if @user.password.length > 0
+          @user.save
+          session[:user_id] = @user.id
+          flash[:notice] = "Thanks for signing up!"
+          redirect "/"
+        else
+          @user.errors.add(:password, "can't be empty")
+        end
       end
+      haml :"login"
     else
       if user = User.authenticate(params[:username], params[:password])
         session[:user_id] = user.id

--- a/test/acceptance/signup_test.rb
+++ b/test/acceptance/signup_test.rb
@@ -38,6 +38,30 @@ describe "signup" do
       assert_match /Username can't be empty/, page.body
     end
 
+    it "requires a password" do
+      visit '/login'
+      fill_in "username", :with => "baseball"
+      click_button "Log in"
+
+      assert_match /Password can't be empty/, page.body
+    end
+
+    it "does not save user to db if there wasn't a password" do
+      visit '/login'
+      fill_in "username", :with => "baseball"
+      click_button "Log in"
+
+      assert_match /Password can't be empty/, page.body
+
+      fill_in "username", :with => "baseball"
+      fill_in "password", :with => "baseball"
+      click_button "Log in"
+
+      refute_match /The username exists; the password you entered was incorrect\. If you are trying to create a new account, please choose a different username/, page.body
+      refute_match /prohibited your account from being created/, page.body
+      assert_match /\//, page.current_url
+    end
+
     it "shows an error if the username is too long" do
       visit '/login'
       fill_in "username", :with => "supercalifragilisticexpialidocious"


### PR DESCRIPTION
Closes issue #344. Disallows creation of accounts with usernames but without passwords.
- When creating an account via the login/signup form:
  -- Checks valid?
  -- Checks for password length
  -- Then saves

Password can't be added to the validations because it's not required for accounts created using
facebook or twitter, but the fb/twitter auth isn't added to the User until after save.
