### PR TITLE
Follow fix

### DIFF
--- a/controllers/users_controller.rb
+++ b/controllers/users_controller.rb
@@ -230,7 +230,7 @@ class Rstatus
     if @user == current_user
       title << "Your followers"
     else
-      title << "#{@user.username} follows"
+      title << "#{@user.username}'s followers"
     end
 
     haml :"users/list", :locals => {:title => title}

--- a/test/acceptance/following_test.rb
+++ b/test/acceptance/following_test.rb
@@ -174,7 +174,7 @@ describe "following" do
     u = Factory(:user, :username => "dfnkt")
 
     visit "/users/#{u.username}/followers"
-    assert_match "#{u.username} follows", page.body
+    assert_match "#{u.username}'s followers", page.body
   end
 
 end


### PR DESCRIPTION
I'm opening this pull request which adds some 'personalization' to the /following and /followers page title. I feel like this is a bit better since we're recognizing the logged in user.

If @user is equal to current user we're going to show you "Your followers" and "You're following", otherwise we're going to say "@user.username's followers" and "@user.username is following".

I think the bigger benefit to this is the test additions. Previously there were no acceptance tests in place (that i found) for testing the title on the /followers page. 

I wouldn't be offended if this was turned down but if that happens I'll probably submit a request with 2 acceptance tests added for /followers with the way the title currently works.
