### PR TITLE
AcceptanceHelper now resets all Capybara sessions between tests

### DIFF
--- a/test/acceptance/acceptance_helper.rb
+++ b/test/acceptance/acceptance_helper.rb
@@ -26,6 +26,7 @@ module AcceptanceHelper
 
   def teardown
     DatabaseCleaner.clean
+    Capybara.reset_sessions!
   end
 
   def omni_mock(username, options={})


### PR DESCRIPTION
Capybara doesn't automatically reset sessions between tests, which is required to ensure that all the tests behave as expected. I have modified the AcceptanceHelper to make it so
