### PR TITLE
Fixing a formatting issue if the number of followers is too wide and "followers" gets pushed down

### DIFF
--- a/app/assets/stylesheets/content.scss.erb
+++ b/app/assets/stylesheets/content.scss.erb
@@ -276,7 +276,8 @@
     color: $text_color + #222;
     padding-top: 1em;
     font-weight: bold;
-    @include column(3);
+    margin-right: 10px;
+    padding-top: 1em;
 
     li {
       list-style-type: none;


### PR DESCRIPTION
fixes #386 - there's still a potential for styling problems if this gets _too_ wide, but it isn't something that would reasonably happen. 
