### PR TITLE
Rake task to fix Authors with nil usernames

### DIFF
--- a/lib/tasks/fixdb.rake
+++ b/lib/tasks/fixdb.rake
@@ -1,0 +1,21 @@
+#rake tasks to update stored data
+namespace :fixdb do
+  desc "Set nil Author usernames"
+  task :set_nil_usernames => :environment do
+    messed_up_authors = Author.where(:username => nil)
+
+    messed_up_authors.each do |author|
+      user = User.where(:author_id => author.id).first
+      if user
+        if Author.count(:username => user.username) > 0
+          puts "Can't set username for Author #{author.id}; Author with #{user.username} already exists"
+        else
+          author.set(:username => user.username)
+          puts "Fixed user #{user.username}."
+        end
+      else
+        puts "Couldn't fix Author #{author.id}; no user found"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Could someone give this a quick lookover before I run this on the production database to fix the users messed up as a result of issue #423? 

I don't have any automated tests for this, but I reverted the commit that fixed issue #423 locally, signed up with twitter so my user was messed up, and running this rake task fixed it.
