### PR TITLE
Removing placeholders from fields since they were just repeating the lab...

### DIFF
--- a/app/views/shared/_field.haml
+++ b/app/views/shared/_field.haml
@@ -12,8 +12,8 @@
         %textarea{:id => attr, :name => attr, :type => "text", :rows => 5}
           = value
       - when :password
-        %input{:id => attr, :name => attr, :type => "password", :placeholder => "•••••••••" }
+        %input{:id => attr, :name => attr, :type => "password"}
       - when :checkbox
         %input{:id => attr, :name => attr, :type => "checkbox", :value => 1}
     - else
-      %input{:id => attr, :name => attr, :type => "text", :value => value, :placeholder => field_label}
+      %input{:id => attr, :name => attr, :type => "text", :value => value}


### PR DESCRIPTION
...el anyway and were confusing in cases

I like placeholders sometimes, but the way this was written it just repeats the label and it seems at best redundant and at worst confusing.

What do yinz think?
