### PR TITLE
Fix ul alignment in Open Source page

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -3,7 +3,7 @@
  *= require "lib/css3buttons"
  *= require "typography"
  *= require "layout"
- *= require "home"
+ *= require "static"
  *= require "content"
  *= require "forms"
  */

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -5,19 +5,19 @@
     margin-bottom: 0;
   }
   .wrap {
-    @include container();      
+    @include container();
   }
 
   #welcome {
     background: $link_color;
     padding: 1.5em;
-    
+
     border-top: 1px solid $link_color + #222;
     border-bottom: 1px solid $link_color + #222;
 
     h1, h3 {
       margin: 0;
-    }      
+    }
 
     #intro {
       float: left;
@@ -27,7 +27,7 @@
 
     }
   }
-  
+
   #pitch {
     border-top: 1px solid $link_color;
     border-bottom: 1px solid #999;
@@ -37,14 +37,14 @@
     .wrap {
       width: 850px;
     }
-    
+
     a {
       color: $text_color;
     }
     a:hover {
       text-decoration: none;
     }
-    
+
     .col {
       width: 270px;
       padding-right: 10px;
@@ -70,14 +70,14 @@
       border: none;
     }
   }
-  
+
   #signup {
     float: right;
     @include clearfix;
     @include rounded(4px);
-    background: $content_background; 
+    background: $content_background;
     padding: 1em;
-    
+
     h3 {
       float: left;
       padding-top: 0.35em;
@@ -86,7 +86,7 @@
     .option {
       float: left;
       padding-right: 1em;
-    } 
+    }
   }
   #content-wrap {
     @include column(11);
@@ -99,7 +99,7 @@
     #bottom {
       @include clearfix;
       padding: 0 1em 1em 1em;
-      
+
       .login {
         float: left;
         font-weight: bold;
@@ -116,5 +116,11 @@
     padding-left: 1em;
     padding-top: 1.5em;
     @include last;
+  }
+}
+
+#open-source {
+  ul {
+    margin-left: 1em;
   }
 }

--- a/app/views/static/open_source.html.haml
+++ b/app/views/static/open_source.html.haml
@@ -1,50 +1,51 @@
-:markdown
-  # Open Source
+#open-source
+  :markdown
+    # Open Source
 
-  rstat.us is entirely, 100% Open Source, and so is our development stack.
+    rstat.us is entirely, 100% Open Source, and so is our development stack.
 
-  ## rstat.us
+    ## rstat.us
 
-  _rstat.us is_ the website you're looking at.
+    _rstat.us is_ the website you're looking at.
 
-  - [Website](http://rstat.us) (duh)
-  - License: [WTFPL](https://github.com/hotsh/rstat.us/raw/be79740ed0f19b3a02e15dbcdbbdb8ca36509819/LICENSE) (essentially public domain)
-  - [Source Code](https://github.com/hotsh/rstat.us)
+    - [Website](http://rstat.us) (duh)
+    - License: [WTFPL](https://github.com/hotsh/rstat.us/raw/be79740ed0f19b3a02e15dbcdbbdb8ca36509819/LICENSE) (essentially public domain)
+    - [Source Code](https://github.com/hotsh/rstat.us)
 
-  ## ruby
+    ## ruby
 
-  _Ruby is_ the programming language that rstat.us is written in.
+    _Ruby is_ the programming language that rstat.us is written in.
 
-  - [Website](http://ruby-lang.org)
-  - License: the [Ruby License](http://www.ruby-lang.org/en/LICENSE.txt)
-  - [Source Code](http://github.com/ruby/ruby)
+    - [Website](http://ruby-lang.org)
+    - License: the [Ruby License](http://www.ruby-lang.org/en/LICENSE.txt)
+    - [Source Code](http://github.com/ruby/ruby)
 
-  ## Rails
+    ## Rails
 
-  _Rails is_ the web framework that we use.
+    _Rails is_ the web framework that we use.
 
-  - [Website](http://rubyonrails.org/)
-  - License: [MIT](https://github.com/rails/rails/blob/master/README.rdoc)
-  - [Source Code](https://github.com/rails/rails)
+    - [Website](http://rubyonrails.org/)
+    - License: [MIT](https://github.com/rails/rails/blob/master/README.rdoc)
+    - [Source Code](https://github.com/rails/rails)
 
-  ## mongodb
+    ## mongodb
 
-  _MongoDB is_ the database that powers rstat.us.
+    _MongoDB is_ the database that powers rstat.us.
 
-  - [Website](http://mongodb.org)
-  - License: [AGPLv3](https://github.com/mongodb/mongo/raw/master/GNU-AGPL-3.0.txt)
-  - [Source Code](https://github.com/mongodb/mongo)
+    - [Website](http://mongodb.org)
+    - License: [AGPLv3](https://github.com/mongodb/mongo/raw/master/GNU-AGPL-3.0.txt)
+    - [Source Code](https://github.com/mongodb/mongo)
 
-  ## ostatus
+    ## ostatus
 
-  _ostatus is_ the protocol we use to send updates.
+    _ostatus is_ the protocol we use to send updates.
 
-  - [Website](http://ostatus.org)
-  - [Spec Document](http://ostatus.org/specification)
+    - [Website](http://ostatus.org)
+    - [Spec Document](http://ostatus.org/specification)
 
-  ## pubsubhubbub
+    ## pubsubhubbub
 
-  _pubsubhubbub is_ a protocol that OStatus builds upon.
+    _pubsubhubbub is_ a protocol that OStatus builds upon.
 
-  - [Website](http://code.google.com/p/pubsubhubbub/)
-  - [Spec Document](http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html)
+    - [Website](http://code.google.com/p/pubsubhubbub/)
+    - [Spec Document](http://pubsubhubbub.googlecode.com/svn/trunk/pubsubhubbub-core-0.3.html)


### PR DESCRIPTION
Quick overview of changes:
- Renamed home.scss.erb to static.scss
- Added #open-source div to open_source view for styling
- Set left margin of ul elements in #open-source to 1em

---

I was browsing the site today and noticed that the list elements on the [Open Source](http://rstat.us/open_source) render outside of the main container in Chrome / Safari. I poked around the site a bit and noticed that this was the only place where this was happening, so I just fixed the list styling for that page.

To keep the stylesheets organized, I renamed `app/assets/stylesheets/home.scss.erb` to `app/assets/stylesheets/static.scss` and added my fix to the bottom of that file. If there is a better place to add my styling, or you think it's safe to apply a left margin to all `ul` elements, just let me know.
# Pics or it didn't happen
### Before

![Before fix](http://i.imgur.com/A9pz5.png)
### After

![Fixed lists](http://i.imgur.com/pSfpb.png)
