### PR TITLE
Render nothing since we don't need to respond to getting an update from ...

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -58,6 +58,7 @@ class SubscriptionsController < ApplicationController
     end
 
     feed.update_entries(request.body.read, request.url, feed.url, request.env['HTTP_X_HUB_SIGNATURE'])
+    render :nothing => true
   end
 
   # A POST is how you subscribe to someone's feed. We want to make sure


### PR DESCRIPTION
...the hub; gets rid of the 'no template subscriptions/post_update' i'm seeing in newrelic

Just goin through the errors I'm seeing in newrelic.

This one comes up when we get a POST from a hub to /subscriptions/:id.atom

ActionView::MissingTemplate: Missing template subscriptions/post_update, application/post_update with {:handlers=>[:erb, :builder, :coffee, :haml], :formats=>[:html], :locale=>[:en, :en]}. Searched in: \* "/app/app/views" 

I don't think we need to respond at all, so just dont render anything.
