### PR TITLE
Fix for #466 

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -86,7 +86,7 @@ class AuthController < ApplicationController
     if user
       auth = Authorization.first(:provider => params[:provider], :user_id => user.id)
       auth.destroy if auth
-      # Without re-seting the user_id for the session we're logged out
+      # Without re-setting the session[:user_id] we're logged out
       session[:user_id] = user.id
     end
     redirect_to "/users/#{params[:username]}/edit"


### PR DESCRIPTION
Looking for feedback on this!

I've tested it locally and confirmed that it fixes the issue of being logged out when removing a twitter authorization, Issue #466

I am working on getting the acceptance test to acknowledge the fact that this is occurring but so far haven't had any luck. I would appreciate any tips anyone could give me. In `tests/acceptance/auth_test.rb` there's a test called `can remove twitter from an account`, this should be the test that needs modified.

I cannot however get it to fail. I tried doing the following (not all at once, mind you):

``` ruby
assert has_link? "Log Out"

assert has_link? "Log Out", {:href => '/logout'}

within(#profile_menu) do
  assert has_link? "Log Out"
end
```

None of these work to get the test to fail, it's like we're not seeing the issue on test. Anyone have ideas how to get the test to fail? Does it have something to do with not working with sessions? I'll be attaching it to this PR once it's ready, don't merge this in yet.
### Update

I believe the inability to get this test to fail is related to Capybara using rack-test. I added `save_and_open_page` to the test and it opens up to `/users/#{@u.username}/edit`. As confirmation I'm going to try and run `auth_test.rb` under the capybara-webkit gem.

I do not think that switching to capybara-webkit is an option because you have to have the Qt bindings installed to install the gem, that's a development dependency I don't want to introduce. But as soon as I have verification of this we can discuss how to handle it.

Does anyone have any issue with the code fix itself?
