### PR TITLE
Fix for Issue #465

### DIFF
--- a/app/assets/stylesheets/forms.scss
+++ b/app/assets/stylesheets/forms.scss
@@ -13,7 +13,7 @@ form {
   .last {
     border: none;
   }
-
+  
   .form-field {
     @include clearfix;
     label {
@@ -132,6 +132,26 @@ form#update-form {
     .submit {
 
     }
+    .button{
+    	line-height:15px;
+    }
+    input[type=text]{
+ 			display: inline-block; 
+ 			padding: 7px 9px; 
+ 			font-size: 12px; 
+ 			line-height:15px; 
+ 			color: #3C3C3D; 
+ 			overflow: visible; 
+ 			border: 1px solid #CACACA; 
+ 			-webkit-border-radius: 2px; 
+ 			-moz-border-radius: 2px; 
+ 			-webkit-background-clip: padding-box; 
+ 			border-radius: 2px; 
+ 			outline: none; 
+ 			position: relative; 
+ 			zoom: 1; 
+ 			*display: inline; 
+    }
   }
 }
 
@@ -144,3 +164,5 @@ form#update-form {
     color: #888;
   }
 }
+
+

--- a/app/views/static/follow.html.haml
+++ b/app/views/static/follow.html.haml
@@ -2,7 +2,7 @@
 %p You can follow your friends from other sites that use the ostatus protocol by providing their webfinger identification.
 %p For examples for some common sites, direct your attention to the bottom of this page.
 
-#follow-form
+#follow-form.search
   = form_tag "/subscriptions" do
     %input{:type => "text", :name => "subscribe_to"}
     %input.button.follow{:type => "submit", :value => "Follow"}


### PR DESCRIPTION
I made a css fix for issue 465. I had to add css for .search input[type=text]. That fixed the box for /users. Then I just added a the .search class to the follow form to apply the same style to /follow.

Also, in Firefox the height of the input box wrong. It looks like it's off by a pixel. I think it is a firefox bug because I used the same css that is applied to the button and it works fine in webkit.

This is my first commit ever but all tests passed. 
