### PR TITLE
Expire sessions after one week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem "database_cleaner"
   gem "fabrication"
   gem "capybara"
+  gem "show_me_the_cookies"
   gem "rocco", :git => "git://github.com/rtomayko/rocco.git"
   gem "pygmentize"
   gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,6 +255,8 @@ GEM
       ffi (>= 1.0.7)
       json_pure
       rubyzip
+    show_me_the_cookies (1.1.0)
+      capybara (~> 1.0)
     simple_oauth (0.1.5)
     simplecov (0.4.2)
       simplecov-html (~> 0.4.4)
@@ -331,6 +333,7 @@ DEPENDENCIES
   rocco!
   rsa
   sass-rails (~> 3.1.0)
+  show_me_the_cookies
   simplecov (~> 0.4.0)
   sinatra
   twitter

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-RstatUs::Application.config.session_store :cookie_store, key: '_rstat.us_session'
+RstatUs::Application.config.session_store :cookie_store, key: '_rstat.us_session', expire_after: 1.week
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information

--- a/test/acceptance/acceptance_helper.rb
+++ b/test/acceptance/acceptance_helper.rb
@@ -13,6 +13,7 @@ module AcceptanceHelper
   include Capybara::DSL
   include Rack::Test::Methods
   include TestHelper
+  include ShowMeTheCookies
 
   OmniAuth.config.test_mode = true
 

--- a/test/acceptance/auth_test.rb
+++ b/test/acceptance/auth_test.rb
@@ -38,6 +38,13 @@ describe "Authorization" do
 
         assert page.has_content?("Login successful")
       end
+
+      it "keeps you logged in for a week" do
+        u = Fabricate(:user)
+        log_in_email(u)
+
+        assert_equal (Date.today + 1.week), get_me_the_cookie("_rstat.us_session")[:expires].to_date
+      end
     end
 
     describe "twitter" do


### PR DESCRIPTION
This pull request will ensure that all sessions are remember for one week, taking care of this issue. Perhaps some sort of textual change should be added to the login screen to ensure that users are aware that their session is saved for a week and that they should logout after using rstat.us on a public or shared computer?

Closes #327
