### PR TITLE
Fixes #448 - Double render error

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -73,6 +73,7 @@ class SubscriptionsController < ApplicationController
     if current_user.following_feed? subscribe_to_feed
       flash[:notice] = "You're already following #{subscribe_to_feed.author.username}."
       redirect_to request.referrer
+      return
     end
 
     # Actually follow!
@@ -81,6 +82,7 @@ class SubscriptionsController < ApplicationController
     unless f
       flash[:notice] = "There was a problem following #{params[:subscribe_to_feed]}."
       redirect_to request.referrer
+      return
     end
 
     # Attempt to inform the hub for remote feeds


### PR DESCRIPTION
If the user clicks on on the follow button rapidly, they will get an error message. I modified the controller not to fall through the check to see if they already follow that user. I'm not a huge fan of the returns, but I couldn't think of any cleaner way to do it.

I tried to write a spec for this, but Capybara automatically refreshes when the button is clicked, so I couldn't make it happen in the acceptance tests, and I couldn't get a generated controller test to work since I'm a rails n00b.
