### PR TITLE
Fixed tests for ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,10 +47,11 @@ group :development, :test do
   gem "show_me_the_cookies"
   gem "rocco", :git => "git://github.com/rtomayko/rocco.git"
   gem "pygmentize"
-  gem "mocha"
+  gem "mocha", "~> 0.11.0"
   gem "vcr"
   gem "simplecov", "~> 0.4.0", :require => false
   gem "launchy"
+  gem "minitest", "~> 2.12.1"
 end
 
 group :test do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -7,7 +7,7 @@ describe User do
   include TestHelper
 
   def stub_superfeedr_request_for_user(user)
-    user_feed_url = CGI.escape(user.feed.url(true)).downcase
+    user_feed_url = CGI.escape(user.feed.url(true))
 
     stub_request(:post, "http://rstatus.superfeedr.com/").
       with(:body => "hub.mode=publish&hub.url=#{user_feed_url}",


### PR DESCRIPTION
Fulfilled hotsh/rstat.us#512.

Everything was easier than it might seem. The problem was in conflicts between outdated gems — `mocha` and `minitest`. I pointed Gemfile entries to latest versions and everything started working like a charm:

```
*** MiniTest integration has not been verified but patching anyway ***
Monkey patching MiniTest >= v2.3.0 <= v2.6.2
Run options: --seed 65141

# Running tests:

..................................................................................................................
.......................................................S..................S.......................................
..SS.........................

Finished tests in 103.527663s, 2.4728 tests/s, 5.3995 assertions/s.

256 tests, 559 assertions, 0 failures, 0 errors, 4 skips
```

I also fixed `test/models/user_test.rb` — test doesn't pass because of down case in stubbed requests.
