### PR TITLE
Fixed a small, yet major typo.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User
 
   # Associations
   # XXX: These don't seem to be getting set when you sign up with Twitter, etc?
-  many :authorizations, :dependant => :destroy
+  many :authorizations, :dependent => :destroy
   belongs_to :author
   key :author_id, ObjectId
 


### PR DESCRIPTION
`:dependant => :destroy` is not a valid association parameter. `:dependent => :destroy`, however, is legit. This may have left us with a huge number of orphaned authorizations.

The authorizations on rstat.us proper should probably be checked to see if there have been any orphans left from account deletions.

Furthermore, it may actually be affecting the random test failures on travis... maybe.
