### PR TITLE
#555 -- Handle Redfinger errors gracefully

### DIFF
--- a/lib/converts_subscriber_to_feed_data.rb
+++ b/lib/converts_subscriber_to_feed_data.rb
@@ -11,7 +11,21 @@ class ConvertsSubscriberToFeedData
       # SAFARI!!!!1 /me shakes his first at the sky
       feed_data.url = "http" + subscriber_url[4..-1]
     when /@/
-      finger_data = QueriesWebFinger.query(subscriber_url)
+      begin
+        finger_data = QueriesWebFinger.query(subscriber_url)
+      rescue StandardError
+        #
+        # TODO Bubble up a better description of what went wrong.
+        #
+        #      We could see any one of the following here:
+        #
+        #      Redfinger::ResourceNotFound
+        #      Nokogiri::SyntaxError        (Bad XML parsed by Redfinger)
+        #      SocketError                  (DNS resolution or connect failure)
+        #      ??? more ???
+        #
+        raise RstatUs::InvalidSubscribeTo
+      end
       feed_data.url = finger_data.url
       feed_data.finger_data = finger_data
     when /^https?:\/\//

--- a/test/lib/converts_subscriber_to_feed_data_test.rb
+++ b/test/lib/converts_subscriber_to_feed_data_test.rb
@@ -58,4 +58,14 @@ describe "converting subscriber to feed data" do
       }.must_raise(RstatUs::InvalidSubscribeTo)
     end
   end
+
+  describe "when a network error occurs retrieving the subscriber info" do
+    it "should not raise a socket error" do
+      email = "ladygaga@twitter"
+      QueriesWebFinger.expects(:query).with(email).throws(SocketError)
+      lambda {
+        ConvertsSubscriberToFeedData.get_feed_data(email)
+      }.must_raise(RstatUs::InvalidSubscribeTo)
+    end
+  end
 end


### PR DESCRIPTION
The SocketError in #555 is probably related to the dodgey host part of the subscribe info (ladygaga@**twitter**).

I think ideally we want Redfinger to do a better job of wrapping these up -- or at least documenting the exceptions.

I'll see if they're willing to take patches, but in the interim here's a fix for rstat.us.
