### PR TITLE
Twitter should have a capital T

### DIFF
--- a/app/views/static/about.html.haml
+++ b/app/views/static/about.html.haml
@@ -2,9 +2,9 @@
   :markdown
     # About Us
 
-    rstat.us is a [100% open source](/open_source) microblogging platform. Development of rstat.us started on March 12, 2011 as a result of frustration about twitter becoming more closed.
+    rstat.us is a [100% open source](/open_source) microblogging platform. Development of rstat.us started on March 12, 2011 as a result of frustration about Twitter becoming more closed.
 
-    We receive no funding. Our hosting costs are very minimal (the main rstat.us site is hosted on [heroku](http://heroku.com)). All code has been written on a volunteer basis and is available for anyone to use under the [CC0](https://raw.github.com/hotsh/rstat.us/HEAD/LICENSE) license (essentially public domain).
+    We receive no funding. Our hosting costs are very minimal (the main rstat.us site is hosted on [heroku](http://heroku.com)). All code has been written on a volunteer basis and is available for anyone to use under the [CC0](https://raw.github.com/hotsh/rstat.us/HEAD/LICENSE) license, which is essentially public domain.
 
     The eventual goal is to make it easy enough for anyone to install the rstat.us code on their own server and run their own node. Because of rstat.us' use of [open protocols](http://ostatus.org), anyone on the main rstat.us node can follow anyone on any other node, and vice versa. We still have work to do to make it easy to install rstat.us' code, but following users on other sites that use the same protocols, like [identi.ca](https://identi.ca/), works today!
 


### PR DESCRIPTION
and remove parentheses that be reworded to a real sentence on the About page.
