### PR TITLE
Short circuit empty search query to show all users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,15 +4,20 @@ class UsersController < ApplicationController
   def index
     @title = "users"
     set_params_page
-    begin
-      @authors = Author.search(params)
-    rescue RegexpError
-      flash[:error] = "Please enter a valid search term"
-      redirect_to users_path and return
-    end
-    unless @authors.empty?
-      @authors = @authors.paginate(:page => params[:page], :per_page => params[:per_page])
-      set_pagination_buttons(@authors, :search => params[:search])
+    if params[:search].blank?
+      @authors = Author.paginate(:page => params[:page], :per_page => params[:per_page])
+    else
+      begin
+        @authors = Author.search(params)
+      rescue RegexpError
+        flash[:error] = "Please enter a valid search term"
+        redirect_to users_path and return
+      end
+
+      unless @authors.empty?
+        @authors = @authors.paginate(:page => params[:page], :per_page => params[:per_page])
+        set_pagination_buttons(@authors, :search => params[:search])
+      end
     end
   end
 

--- a/test/acceptance/user_search_test.rb
+++ b/test/acceptance/user_search_test.rb
@@ -22,6 +22,12 @@ describe "user search" do
     assert has_content?("Sorry, no users that match.")
   end
 
+  it "displays all users if there is no search query" do
+    visit "/users?search="
+    assert_equal 200, page.status_code
+    assert has_content?("zebra")
+  end
+
   it "finds users by substring regex match (do we want this?)" do
     visit "/users?search=ebr"
     assert has_content?("zebra")


### PR DESCRIPTION
- Handles search query with no results correctly.
- Closes #544 by choosing to show all users for empty search.
