### PR TITLE
Adds a javascript engine to avoid errors running tests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,5 +65,5 @@ end
 
 group :test do
   gem "webmock", "~> 1.6.4"
-  gem "therubyracer"
+  gem "therubyracer", "~> 0.9.9"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -308,7 +308,7 @@ DEPENDENCIES
   sass-rails (~> 3.2.5)
   show_me_the_cookies (~> 1.1.0)
   simplecov (~> 0.4.0)
-  therubyracer
+  therubyracer (~> 0.9.9)
   twitter (~> 3.5.0)
   tzinfo (~> 0.3.29)
   uglifier (~> 1.0.0)


### PR DESCRIPTION
On Linux, a javascript engine is required to run the tests. So, I just
added one to the tests subgroup of the gemfile. It won't hurt
production, but it is annoying to have to add this manually every time I
want to run the tests. :(
