### PR TITLE
Commit policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,13 @@ pull requests to the hotsh/rstat.us master branch.
 This _also_ means that you _could_ push your commits directly to
 hotsh/rstat.us without going through a pull request. We ask that you not do
 this, however, so that any code on master has been seen by 2 sets of eyes
-(tests don't always catch everything!) We reserve the right to take away this
-permission, but in general we trust you to give it to you. :heart: :heart:
+(tests don't always catch everything!) This does not apply to branches other
+than master; if there is long-term collaboration happening, create a feature
+branch and feel free to push directly to that (but have commits reviewed
+before merging that branch into master).
+
+We reserve the right to take away this permission, but in general we trust you
+to give it to you. :heart: :heart:
 
 Source code documentation
 -------------------------


### PR DESCRIPTION
This is to document the policy of who is on the team with push+pull access to the hotsh/rstat.us repo that we've been discussing [on the mailing list](http://librelist.com/browser//rstatus/2012/8/19/another-policy-commit-bit/) and [on issue 587](https://github.com/hotsh/rstat.us/pull/587). And look, I'm now following said policy! As I told wilkie in IRC though, I reserve the right to go back to pushing my own changes directly if everyone disappears again :(

Oh, and wrapping the README at 80 chars.
