### PR TITLE
Bugfix/webfinger tests and xrd fixes

### DIFF
--- a/app/views/xml/webfinger/xrd.haml
+++ b/app/views/xml/webfinger/xrd.haml
@@ -5,8 +5,8 @@
   %Alias= "#{@base_url}users/#{@user.username}"
   %Link{:rel => "http://webfinger.net/rel/profile-page", :type => "text/html", :href => "#{@base_url}users/#{@user.username}"}
   %Link{:rel => "http://schemas.google.com/g/2010#updates-from", :href => "#{@base_url}feeds/#{@user.feed.id}.atom"}
-  %Link{:rel => "http://ostatus.org/schema/1.0/subscribe", :href => "#{@base_url}subscriptions?url={uri}&_method=post"}
   %Link{:rel => "salmon", :href => "#{@base_url}feeds/#{@user.feed.id}/salmon"}
   %Link{:rel => "http://salmon-protocol.org/ns/salmon-replies", :href => "#{@base_url}feeds/#{@user.feed.id}/salmon"}
   %Link{:rel => "http://salmon-protocol.org/ns/salmon-mention", :href => "#{@base_url}feeds/#{@user.feed.id}/salmon"}
+  %Link{:rel => "http://ostatus.org/schema/1.0/subscribe", :template => "#{@base_url}subscriptions?url={uri}&_method=post"}
   %Link{:rel => "magic-public-key", :href => "data:application/magic-public-key,#{@user.author.public_key}"}

--- a/test/acceptance/webfinger_test.rb
+++ b/test/acceptance/webfinger_test.rb
@@ -76,7 +76,7 @@ describe "Webfinger" do
       regex = /^http(?:s)?:\/\/.*\/subscriptions\?url=\{uri\}\&_method=post$/
       subscription_rel = "http://ostatus.org/schema/1.0/subscribe"
       subscription_uri = @xml.xpath("//xmlns:Link[@rel='#{subscription_rel}']")
-      subscription_uri.first.attr("href").must_match regex
+      subscription_uri.first.attr("template").must_match regex
     end
   end
 


### PR DESCRIPTION
A set of acceptance tests (and small fixes to get them to pass, yay!) to ensure that the xrd that is being hosted by rstat.us contains valid links to our routes.

One fix was to ensure that the subscription url template is actually a template instead of an href. This link is used by remote ostatus nodes to know what route to ping when somebody wants to follow a remote user using the remote's user interface. I have no idea if that actually works, though, but that's more an issue with the route logic than its presence in the xrd.

This completes the xrd acceptance tests started by earlier pull request #601 which added checks for salmon links.
