### PR TITLE
Show Updates link in header even when you're a logged in user. Finishes ...

### DIFF
--- a/app/views/shared/menu/_main.haml
+++ b/app/views/shared/menu/_main.haml
@@ -1,5 +1,5 @@
 %ul.menu#main
   != menu_item("Home", "/", :rel => "index")
-  != menu_item("Updates", "/updates", :rel => "messages-all") unless current_user
+  != menu_item("Updates", "/updates", :rel => "messages-all")
   != menu_item("Search", "/search", :rel => "messages-search")
   != menu_item("Users", "/users", :rel => "users-search")


### PR DESCRIPTION
...#586.

Along with #619, this addresses #586: World is now Updates, and the Updates link remains in the header even when you're logged in and links to the Updates tab.
