### PR TITLE
Use image_url as the variable/attribute name consistently in Author

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -75,7 +75,7 @@ class Author
     username   = user['username']
     website    = user['urls']['Website']
     bio        = user['description']
-    image      = user['image']
+    image_url  = user['image']
     remote     = user['url']
 
     # Creates an Author object with the details
@@ -84,7 +84,7 @@ class Author
       username:   username,
       website:    website,
       bio:        bio,
-      image_url:  image,
+      image_url:  image_url,
       remote_url: remote,
       domain:     domain
     )
@@ -92,23 +92,23 @@ class Author
 
   def self.new_from_session!(session, params, domain)
     new(
-      :name     => session[:name],
-      :username => params[:username],
-      :website  => session[:website],
-      :bio      => session[:description],
-      :image    => session[:image],
-      :domain   => domain
+      :name      => session[:name],
+      :username  => params[:username],
+      :website   => session[:website],
+      :bio       => session[:description],
+      :image_url => session[:image],
+      :domain    => domain
     )
   end
 
   def self.create_from_session!(session, params, domain)
     create!(
-      :name     => session[:name],
-      :username => params[:username],
-      :website  => session[:website],
-      :bio      => session[:description],
-      :image    => session[:image],
-      :domain   => domain
+      :name      => session[:name],
+      :username  => params[:username],
+      :website   => session[:website],
+      :bio       => session[:description],
+      :image_url => session[:image],
+      :domain    => domain
     )
   end
 

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -11,6 +11,25 @@ describe Author do
     assert Author.create_from_hash!(hash, "rstat.us").is_a?(Author)
   end
 
+  describe "new_from_session!" do
+    it "has an image_url if the session has image" do
+      session_hash = {:image => "foo.png"}
+      a = Author.new_from_session!(session_hash, {}, "http://example.com")
+      a.save!
+
+      a.image_url.must_equal "foo.png"
+    end
+  end
+
+  describe "create_from_session!" do
+    it "has an image_url if the session has image" do
+      session_hash = {:image => "foo.png"}
+      a = Author.create_from_session!(session_hash, {}, "http://example.com")
+
+      a.image_url.must_equal "foo.png"
+    end
+  end
+
   it "stores the domain of a local user by normalizing the base url" do
     @author.domain = "http://example.com/"
     @author.save


### PR DESCRIPTION
Because the session has a key "image" but our attribute is "image_url" and creating an Author means switching between those two, since 96cc35c new accounts created with twitter wont have working avatars because it was being saved on the model as "image".

There are ~650 Authors in the database that have this issue, I'll fix them after this is live.
