### PR TITLE
Change twitter avatar URLs to the domain that matches their SSL cert so ...

### DIFF
--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -26,10 +26,16 @@ class Author
   key :use_ssl,   Boolean
 
   validates_presence_of :domain
-  
+
   # Normalize the domain so we can use them the same way
   before_save :normalize_domain
+
+  # Make sure the image url uses https
   before_save :https_image_url
+
+  # Twitter has an SSL cert that doesn't match the domain but we can
+  # change the domain to match the cert and the avatars work
+  before_save :modify_twitter_image_url_domain
 
   # The Author has a profile and with that various entries
   key :name,      String
@@ -249,6 +255,10 @@ class Author
 
   def https_image_url
     self.image_url.sub!(/^http:/, 'https:') if self.image_url.present?
+  end
+
+  def modify_twitter_image_url_domain
+    self.image_url.sub!(/a\d.twimg.com/, "twimg0-a.akamaihd.net") if self.image_url.present?
   end
 
   def to_param

--- a/test/models/author_test.rb
+++ b/test/models/author_test.rb
@@ -32,16 +32,32 @@ describe Author do
     assert_equal @author.remote_url, @author.url
   end
 
-  it "ensures that image_url is always https" do
-    @author.image_url = 'http://example.net/cool-avatar'
-    @author.save!
-    assert_equal 'https://example.net/cool-avatar', @author.image_url
+  describe "https_image_url" do
+    it "ensures that image_url is always https" do
+      @author.image_url = 'http://example.net/cool-avatar'
+      @author.save!
+      assert_equal 'https://example.net/cool-avatar', @author.image_url
+    end
+
+    it "ensures that https image_urls are untouched" do
+      @author.image_url = 'https://example.net/cool-avatar'
+      @author.save!
+      assert_equal 'https://example.net/cool-avatar', @author.image_url
+    end
   end
 
-  it "ensures that https image_urls are untouched" do
-    @author.image_url = 'https://example.net/cool-avatar'
-    @author.save!
-    assert_equal 'https://example.net/cool-avatar', @author.image_url
+  describe "modify_twitter_image_url_domain" do
+    it "changes a twitter image URL to use the domain that matches the cert" do
+      @author.image_url = 'https://a3.twimg.com/whatever'
+      @author.save!
+      assert_equal 'https://twimg0-a.akamaihd.net/whatever', @author.image_url
+    end
+
+    it "leaves other image urls alone" do
+      @author.image_url = 'https://example.net/cool-avatar'
+      @author.save!
+      assert_equal 'https://example.net/cool-avatar', @author.image_url
+    end
   end
 
   describe "#fully_qualified_name" do


### PR DESCRIPTION
...that they'll work with SSL

This is somewhat of a stopgap measure to make more twitter avatars work.

@wilkie figured this out :)

I'll run Author.save! on all the existing authors once this is live.
