### PR TITLE
Only look for the config file if we're actually going to end up using it

### DIFF
--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -5,8 +5,6 @@
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
 
-config_file = File.expand_path(File.join(Rails.root, '/config/config.yml'))
-config = YAML.load_file(config_file)
 
 if ENV["SECRET_TOKEN"].blank?
   if Rails.env.production?
@@ -15,6 +13,8 @@ if ENV["SECRET_TOKEN"].blank?
     # Generate the key and test away
     ENV["SECRET_TOKEN"] = RstatUs::Application.config.secret_token = SecureRandom.hex(30)
   else
+    config_file = File.expand_path(File.join(Rails.root, '/config/config.yml'))
+    config = YAML.load_file(config_file)
     # Generate the key, set it for the current environment, update the yaml file and move on
     ENV["SECRET_TOKEN"] = config[Rails.env]['SECRET_TOKEN'] = SecureRandom.hex(30)
     File.open(config_file, 'w') { |file| file.write(config.to_yaml) }


### PR DESCRIPTION
I just tried deploying to heroku with a set of commits containing 2c92c82444 and apparently heroku can't find the config file, but it doesn't actually need to (heroku uses the env variables), so this commit just moves those lines into the case that actually uses the config file.

These are the errors I was seeing in the heroku logs:

2012-09-28T16:25:21+00:00 app[web.2]: /usr/local/lib/ruby/1.9.1/syck.rb:145:in `initialize': No such file or directory - /app/config/config.yml (Errno::ENOENT)
2012-09-28T16:25:21+00:00 app[web.2]:   from /usr/local/lib/ruby/1.9.1/syck.rb:145:in`open'
2012-09-28T16:25:21+00:00 app[web.2]:   from /usr/local/lib/ruby/1.9.1/syck.rb:145:in `load_file'
2012-09-28T16:25:21+00:00 app[web.2]:   from /app/config/initializers/secret_token.rb:9:in`<top (required)>'
