### PR TITLE
Changed redirect path to homepage after replying to an update from a use...

### DIFF
--- a/app/controllers/updates_controller.rb
+++ b/app/controllers/updates_controller.rb
@@ -58,7 +58,9 @@ class UpdatesController < ApplicationController
       flash[:notice] = "Update created."
     end
 
-    if request.referrer
+    reply_redirect = request.referrer.include?("reply=") ? true : false 
+
+    if request.referrer and reply_redirect == false
       redirect_to request.referrer
     else
       redirect_to root_path

--- a/test/acceptance/update_test.rb
+++ b/test/acceptance/update_test.rb
@@ -69,6 +69,20 @@ describe "update" do
       assert_match url, page.current_url, "Ended up on #{page.current_url}, expected to be on #{url}"
     end
   end
+  
+  it "it redirect to the home page after making an update as a reply to another update found on the original updater's profile page" do
+    log_in_as_some_user
+    u2 = Fabricate(:user)
+    reply_update = Fabricate(:update)
+    u2.feed.updates << reply_update
+
+    visit "/users/#{u2.username}"
+    click_link "reply"
+    fill_in "text", :with => "@#{u2.username} This is a great reply update"
+    VCR.use_cassette('publish_to_hub') { click_button "Share" }
+
+    assert_equal false, page.current_url.include?("reply="), "Ended up on #{page.current_url}, expected to be on http://www.example.com/"
+  end
 
   it "shows one update" do
     update = Fabricate(:update)


### PR DESCRIPTION
This pull request is in regards to issue 654 https://github.com/hotsh/rstat.us/issues/654

I have changed the updates_controller create method to check the request url for the reply parameter and if found, redirects to the homepage instead of keeping the reply paramater in the redirect.

I have also written a test to cover this new redirect logic in update_test.rb
