### PR TITLE
Escaping the autocomplete regexp to fix #666

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -241,7 +241,7 @@ class User
       return []
     end
 
-    query = '^' + query.downcase + '.*'
+    query = '^' + Regexp.escape(query) + '.*'
     following.inject([]) do |result, obj|
       if /#{query}/i =~ obj.author.fully_qualified_name
         result << { :label => obj.author.fully_qualified_name.downcase }

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -320,6 +320,11 @@ describe User do
       @result = @bob.autocomplete('ta')
       assert_equal [], @result
     end
+
+    it "escapes special characters" do
+      @result = @bob.autocomplete('r+(')
+      assert_equal [], @result
+    end
   end
 
   describe "self#find_by_case_insensitive_username" do


### PR DESCRIPTION
This is the test and code that fixes hotsh/rstat.us#666, regarding the sanitization of the autocomplete regexp.

I also deleted an extra `.downcase` that wasn't needed since the comparison ignores case.

Let me know of any comment you may have.
