### PR TITLE
Ignore vendor/bundle folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ log/*.log*
 capybara*
 .DS_Store
 .bundle
+vendor/bundle


### PR DESCRIPTION
Bundler installs gems in vendor/bundle by default when using the
`--deployment` switch.
