### PR TITLE
Style the focus state of buttons to match their hover state.

### DIFF
--- a/app/assets/stylesheets/lib/css3buttons.scss.erb
+++ b/app/assets/stylesheets/lib/css3buttons.scss.erb
@@ -2,6 +2,7 @@
 
 .button { @include copy-face; display: inline-block; padding: 7px 9px; font-size: 12px; color: #3C3C3D; text-shadow: 1px 1px 0 #FFFFFF; background: #ECECEC 0 0 no-repeat; white-space: nowrap; overflow: visible; cursor: pointer; text-decoration: none; border: 1px solid #CACACA; -webkit-border-radius: 2px; -moz-border-radius: 2px; -webkit-background-clip: padding-box; border-radius: 2px; outline: none; position: relative; zoom: 1; *display: inline; }
 .button.primary { font-weight: bold }
+.button:focus,
 .button:hover { color: #FFFFFF; border-color: #4c9092; text-decoration: none; text-shadow: -1px -1px 0 rgba(0,0,0,0.3); background-position: 0 -40px; background-color: $link_color; }
 .button:active,
 .button.active { background-position: 0 -81px; border-color: #4c9092; background-color: $link_color; color: #FFFFFF; text-shadow: none; }


### PR DESCRIPTION
This implements a fix for [Issue 627](https://github.com/hotsh/rstat.us/issues/627).
