### PR TITLE
Upgrade rake

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       rdoc (~> 3.4)
       thor (>= 0.14.6, < 2.0)
     raindrops (0.10.0)
-    rake (0.9.2.2)
+    rake (10.0.1)
     ratom (0.7.2)
       libxml-ruby (~> 2.3.2)
     rdiscount (1.6.8)


### PR DESCRIPTION
When I installed the new 1.9.3 that came out, rake 10 was what was installed by default. I think we should try and keep rake up to date since it's such a fundamental gem that lots of other things rely on.
