### PR TITLE
Fixes issue #532. Don't even try authenticating by checking hashed_passw...

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,6 +329,7 @@ class User
   def self.authenticate(username, pass)
     user = User.find_by_case_insensitive_username(username)
     return nil if user.nil?
+    return nil unless user.hashed_password
     return user if BCrypt::Password.new(user.hashed_password) == pass
     nil
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -348,4 +348,19 @@ describe User do
       assert_equal nil, User.find_by_case_insensitive_username(".mg")
     end
   end
+
+  describe "accounts that only have twitter auth, no password" do
+    it "should not error if you try to log in with a password" do
+      u = Fabricate(:user)
+
+      # This is contrived; users should no longer end up in this state.
+      u.update_attribute(:hashed_password, nil)
+
+      # Issue #532 is this throwing a BCrypt::Errors::InvalidHash exception;
+      # the correct behavior is returning nil.
+      authenticated_user = User.authenticate(u.username, "anything")
+
+      assert authenticated_user.nil?
+    end
+  end
 end


### PR DESCRIPTION
...ord if there isn't one-- just fail.

Created a contrived test that sets up this scenario since it doesn't seem to happen with new users anymore?
