### PR TITLE
Bugfix/feed service tests

### DIFF
--- a/test/services/feed_service_test.rb
+++ b/test/services/feed_service_test.rb
@@ -3,8 +3,6 @@ require_relative '../test_helper'
 require 'mocha/setup'
 
 describe FeedService do
-  include TestHelper
-
   describe "#find_or_create!" do
     let(:service)       { FeedService.new(target_feed) }
     let(:existing_feed) { mock }


### PR DESCRIPTION
The original tests weren't... um... doing much. :) I mean... look at:

https://github.com/hotsh/rstat.us/blob/master/test/services/feed_service_test.rb#L62-L64

Stubs out every method, asserts that it calls the stub and gets the value stubbed. That pretty much tests ruby's precedence order for the `||` operator. Apparently, there was this urge in the original developer to stub out private methods. But since FeedService is entirely private methoded, that's not ideal. For instance: `FeedService#find_feed_by_remote_url` is never called by a test.

Private methods are forced integrations. They must be invoked to test behavior of the public methods. Otherwise, they will never be covered. I did, however, remove db dependency.

I also snuck in the mocha deprecation fix with a mocha update here because this was one of the files which involved the issue, I believe.
## Speed

I'm trying to refactor tests in sight of #706 and here are the benchmarks for `test/services/feed_service_test.rb`
### Original

```
$ rake test:file[test/services/feed_service_test.rb]
test/services/feed_service_test.rb
Rack::File headers parameter replaces cache_control after Rack 1.5.
Run options: --seed 19878

# Running tests: .....

Finished tests in 0.200287s, 24.9641 tests/s, 24.9641 assertions/s.
```
### After ensuring internal codepaths are stubbed

```
$ rake test:file[test/services/feed_service_test.rb]
test/services/feed_service_test.rb
Rack::File headers parameter replaces cache_control after Rack 1.5.
Run options: --seed 31669

# Running tests: .....

Finished tests in 0.195127s, 25.6243 tests/s, 25.6243 assertions/s.
```
### Stubs out db calls, external codepaths

```
$ rake test:file[test/services/feed_service_test.rb]
test/services/feed_service_test.rb
Rack::File headers parameter replaces cache_control after Rack 1.5.
Run options: --seed 24722

# Running tests: .....

Finished tests in 0.202075s, 24.7433 tests/s, 29.6920 assertions/s.
```

I didn't run them on the same seed, but still, no change! These tests are as simple as they can be. I have entire projects with around 200 assertions that run faster than these 5 tests. There is apparently a high upfront overhead of, apparently, 0.2s.
