### PR TITLE
Bugfix/subscriber to feed data converter test speed

### DIFF
--- a/test/services/subscriber_to_feed_data_converter_test.rb
+++ b/test/services/subscriber_to_feed_data_converter_test.rb
@@ -1,6 +1,9 @@
 require 'minitest/autorun'
 require 'mocha/setup'
+
 require 'socket'
+require_relative '../../app/models/feed_data'
+require_relative '../../app/services/finger_service'
 require_relative '../../app/services/subscriber_to_feed_data_converter'
 
 FakeFingerData = Struct.new(:url)
@@ -9,71 +12,73 @@ module RstatUs
   class InvalidSubscribeTo < StandardError; end
 end
 
-describe "converting a subscriber to feed data" do
-  describe "when a Safari 'feed://' scheme is provided" do
-    it "should replace feed:// with http://" do
-      feed_data = SubscriberToFeedDataConverter.new("feed://stuff").get_feed_data!
+describe SubscriberToFeedDataConverter do
+  describe "converting a subscriber to feed data" do
+    describe "when a Safari 'feed://' scheme is provided" do
+      it "should replace feed:// with http://" do
+        feed_data = SubscriberToFeedDataConverter.new("feed://stuff").get_feed_data!
 
-      assert_equal "http://stuff", feed_data.url
+        assert_equal "http://stuff", feed_data.url
+      end
     end
-  end
 
-  describe "when an email address is provided" do
-    it "should finger the user" do
-      email = "somebody@somewhere.com"
+    describe "when an email address is provided" do
+      it "should finger the user" do
+        email = "somebody@somewhere.com"
 
-      mock_finger_service = mock
-      FingerService.expects(:new).with(email).returns(mock_finger_service)
+        mock_finger_service = mock
+        FingerService.expects(:new).with(email).returns(mock_finger_service)
 
-      finger_data = FakeFingerData.new("url")
-      mock_finger_service.expects(:finger!).returns(finger_data)
+        finger_data = FakeFingerData.new("url")
+        mock_finger_service.expects(:finger!).returns(finger_data)
 
-      new_feed_data = SubscriberToFeedDataConverter.new(email).get_feed_data!
+        new_feed_data = SubscriberToFeedDataConverter.new(email).get_feed_data!
 
-      assert_equal "url", new_feed_data.url
-      assert_equal finger_data, new_feed_data
+        assert_equal "url", new_feed_data.url
+        assert_equal finger_data, new_feed_data
+      end
     end
-  end
 
-  describe "when an http:// URL is provided" do
-    it "should use the subscriber URL as the feed URL" do
-      feed_url  = "http://feed.me"
-      feed_data = SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
+    describe "when an http:// URL is provided" do
+      it "should use the subscriber URL as the feed URL" do
+        feed_url  = "http://feed.me"
+        feed_data = SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
 
-      assert_equal feed_url, feed_data.url
+        assert_equal feed_url, feed_data.url
+      end
     end
-  end
 
-  describe "when an https:// URL is provided" do
-    it "should use the subscriber URL as the feed URL" do
-      feed_url  = "https://feed.me"
-      feed_data = SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
+    describe "when an https:// URL is provided" do
+      it "should use the subscriber URL as the feed URL" do
+        feed_url  = "https://feed.me"
+        feed_data = SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
 
-      assert_equal feed_url, feed_data.url
+        assert_equal feed_url, feed_data.url
+      end
     end
-  end
 
-  describe "when we cannot currently understand the subscriber URL" do
-    it "should raise an exception so that we dont try and look it up as a file" do
-      feed_url  = "Gemfile.lock"
+    describe "when we cannot currently understand the subscriber URL" do
+      it "should raise an exception so that we dont try and look it up as a file" do
+        feed_url  = "Gemfile.lock"
 
-      lambda {
-        SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
-      }.must_raise(RstatUs::InvalidSubscribeTo)
+        lambda {
+          SubscriberToFeedDataConverter.new(feed_url).get_feed_data!
+        }.must_raise(RstatUs::InvalidSubscribeTo)
+      end
     end
-  end
 
-  describe "when a network error occurs retrieving the subscriber info" do
-    it "consumes the SocketError and re-raises at an RstatUs exception" do
-      email = "ladygaga@twitter"
+    describe "when a network error occurs retrieving the subscriber info" do
+      it "consumes the SocketError and re-raises at an RstatUs exception" do
+        email = "ladygaga@twitter"
 
-      mock_finger_service = mock
-      FingerService.expects(:new).with(email).returns(mock_finger_service)
-      mock_finger_service.expects(:finger!).throws(SocketError)
+        mock_finger_service = mock
+        FingerService.expects(:new).with(email).returns(mock_finger_service)
+        mock_finger_service.expects(:finger!).throws(SocketError)
 
-      lambda {
-        SubscriberToFeedDataConverter.new(email).get_feed_data!
-      }.must_raise(RstatUs::InvalidSubscribeTo)
+        lambda {
+          SubscriberToFeedDataConverter.new(email).get_feed_data!
+        }.must_raise(RstatUs::InvalidSubscribeTo)
+      end
     end
   end
 end


### PR DESCRIPTION
So. The SubscriberToFeedDataConverter tests won't run on their own. I had to add a bunch of dependencies. I don't really understand why the community shies away from requires in actual files where they depend on things.
## Speed

Results related to #706.
### Original

```
$ rake test:file[test/services/subscriber_to_feed_data_converter_test.rb]

6 tests, 1 assertions, 1 failures, 5 errors, 0 skips
```
### Um. Alright. After requiring the dependencies

```
$ rake test:file[test/services/subscriber_to_feed_data_converter_test.rb]

Finished tests in 0.005167s, 1161.2156 tests/s, 2128.8953 assertions/s.
```

Well then! Fair enough.
### User benchmark

```
$ time rake test:file[test/services/subscriber_to_feed_data_converter_test.rb]

Finished tests in 0.005005s, 1198.7727 tests/s, 2197.7499 assertions/s.

real    0m7.605s
user    0m7.277s
sys     0m0.303s
```
### rake test:services

```
$ time rake test:services

Finished tests in 0.258596s, 65.7395 tests/s, 85.0747 assertions/s.

real    0m19.699s
user    0m18.983s
sys     0m0.667s
```

Overhead of 18-19 seconds.
### rake test:services with #743

```
$ time rake test:services

Finished tests in 0.068574s, 247.9061 tests/s, 320.8196 assertions/s.

real    0m19.544s
user    0m18.800s
sys     0m0.693s
```

No discernible improvement upon the overhead, which constitutes 28500% of the total user time.

However, this overhead seems to be per file! The file alone was only 7s.
