### PR TITLE
Fix for undefined method `start_with?' for nil:NilClass in Rakefile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
     kgio (2.7.4)
     launchy (2.0.5)
       addressable (~> 2.2.6)
-    libv8 (3.11.8.13)
     libwebsocket (0.1.5)
       addressable
     libxml-ruby (2.3.3)
@@ -212,7 +211,6 @@ GEM
     rdoc (3.12.1)
       json (~> 1.4)
     redcarpet (1.17.2)
-    ref (1.0.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rsa (0.1.4)
@@ -239,9 +237,6 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.11.3)
-      libv8 (~> 3.11.8.12)
-      ref
     thin (1.5.0)
       daemons (>= 1.0.9)
       eventmachine (>= 0.12.6)
@@ -326,7 +321,6 @@ DEPENDENCIES
   sass-rails (~> 3.2.5)
   show_me_the_cookies (~> 1.1.0)
   simplecov (~> 0.4.0)
-  therubyracer (~> 0.11.3)
   thin (~> 1.5.0)
   tire (~> 0.4.1)
   twitter (~> 3.5.0)

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-if ARGV[0].start_with?('test')
+if ARGV[0] && ARGV[0].start_with?('test')
   load 'lib/tasks/minitest.rake'
 else
   require File.expand_path('../config/application', __FILE__)


### PR DESCRIPTION
There's a minor issue when attempting to run any rake task that does not contain any arguments:

<pre>
bundle exec rake -T

rake aborted!
undefined method `start_with?' for nil:NilClass
/Users/dtykocki/Development/ruby/rstat.us/Rakefile:5:in `<top (required)>'
/Users/dtykocki/.rvm/gems/ruby-1.9.3-p374@rstatus/bin/ruby_noexec_wrapper:14:in `eval'
/Users/dtykocki/.rvm/gems/ruby-1.9.3-p374@rstatus/bin/ruby_noexec_wrapper:14:in `<main>'
(See full trace by running task with --trace)

</pre>
