### PR TITLE
Adds rels for user profile links to followers, following, and updates.

### DIFF
--- a/app/views/shared/sidebar/_profile.haml
+++ b/app/views/shared/sidebar/_profile.haml
@@ -10,17 +10,17 @@
           @#{current_user.username}
       %ul.stats
         %li.update-count
-          %a{ :href => "/users/#{current_user.username}" }
+          %a{ :href => "/users/#{current_user.username}", :rel => 'messages-me' }
             .icon
             %span.number= current_user.feed.updates.count
             Updates
         %li.following-count
-          %a{ :href => "/users/#{current_user.username}/following" }
+          %a{ :href => "/users/#{current_user.username}/following", :rel => 'users-friends' }
             .icon
             %span.number= current_user.following.length
             Following
         %li.follower-count.last
-          %a{ :href => "/users/#{current_user.username}/followers" }
+          %a{ :href => "/users/#{current_user.username}/followers", :rel => 'users-followers' }
             .icon
             %span.number= current_user.followers.length
             Followers

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -43,17 +43,17 @@
 
           %ul.stats
             %li.update-count
-              %a{ :href => "#profile_updates" }
+              %a{ :href => "#profile_updates", :rel => 'messages-me' }
                 %span.icon
                 %span.number= @author.feed.updates.count
                 Updates
             %li.following-count
-              %a{ :href => "/users/#{@author.username}/following" }
+              %a{ :href => "/users/#{@author.username}/following", :rel => 'users-friends' }
                 %span.icon
                 %span.number= @author.user.following.length
                 Following
             %li.follower-count
-              %a{ :href => "/users/#{@author.username}/followers" }
+              %a{ :href => "/users/#{@author.username}/followers", :rel => 'users-followers'}
                 %span.icon
                 %span.number= @author.user.followers.length
                 Followers

--- a/test/acceptance/alps/user_profile_test.rb
+++ b/test/acceptance/alps/user_profile_test.rb
@@ -57,5 +57,34 @@ describe "ALPS single user" do
     end
   end
 
+  it "has the followers link in a rel=users-followers" do
+    visit "/users/#{@user.username}"
+    within "li.user" do
+      assert has_selector?(
+        :xpath,
+        "//a[contains(@rel, 'users-followers') and @href='/users/#{@user.username}/followers']"
+      )
+    end
+  end
+
+  it "has the following link in a rel=users-friends" do
+    visit "/users/#{@user.username}"
+    within "li.user" do
+      assert has_selector?(
+        :xpath,
+        "//a[contains(@rel, 'users-friends') and @href='/users/#{@user.username}/following']"
+      )
+    end
+  end
+
+  it "has the updates link in a rel=messages-me" do
+    visit "/users/#{@user.username}"
+    within "li.user" do
+      assert has_selector?(
+        :xpath,
+        "//a[contains(@rel, 'messages-me') and @href='#profile_updates']"
+      )
+    end
+  end
 end
 


### PR DESCRIPTION
According to ALPS, the following rels are used on <a> tags:
- **messages-me**: Applied to an A tag. A reference to a list representation
  of all the messages posted by the designated user.
- **users-friends**: Applied to an A tag. A reference to list representation
  of the designated user's friend users.
- **users-followers**: Applied to an A tag. A reference to list representation
  of the users who follow the designated user.

They indeed point to lists of `li.user`'s so I've added them.
