### PR TITLE
Adds a checkbox that might make it a bit annoying to post spam on rstatus

### DIFF
--- a/app/assets/javascripts/main.js.coffee.erb
+++ b/app/assets/javascripts/main.js.coffee.erb
@@ -123,6 +123,10 @@ jQuery $ ->
   if( $("#tweet").length > 0)
     $("#tweet").change(recordTickyboxChange)
 
+  # Check and hide the spam checkbox
+  $("#not-a-spammer").attr('checked', true)
+  $("#spam-prevention").hide()
+
   #########################################
   # Delete account
   #########################################

--- a/app/views/updates/_form.html.haml
+++ b/app/views/updates/_form.html.haml
@@ -11,6 +11,9 @@
           %label{:for => "tweet"} Twitter
 
     %input#update-referral{:type => 'hidden', :name => 'referral_id', :value => @update_id}
+    #spam-prevention.input-checkbox
+      %input{:type => "checkbox", :name => "not-a-spammer", :id => "not-a-spammer", :checked => false}
+      %label{:for => "not-a-spammer"} I am not a spammer
     %input#update-button.button{:type => "submit", :value => "Share"}
     #update-count{:title => 'Characters remaining'}
 

--- a/test/acceptance/auth_test.rb
+++ b/test/acceptance/auth_test.rb
@@ -8,6 +8,7 @@ describe "Authorization" do
   def assert_publish_succeeds update_text
     VCR.use_cassette('publish_to_hub') do
       fill_in "text", :with => update_text
+      check 'not-a-spammer'
       click_button "Share"
     end
 

--- a/test/acceptance/update_test.rb
+++ b/test/acceptance/update_test.rb
@@ -53,6 +53,7 @@ describe "update" do
       VCR.use_cassette('publish_update') do
         visit "/"
         fill_in 'update-textarea', :with => update_text
+        check 'not-a-spammer'
         click_button :'update-button'
       end
 
@@ -63,6 +64,20 @@ describe "update" do
       post "/updates", {:text => "probably spam"}
 
       last_response.status.must_equal 302
+    end
+  end
+
+  describe "spam mitigation" do
+    describe "without javascript" do
+      it "does not allow users that don't check the 'I am not a spammer' box to create an update" do
+        log_in_as_some_user
+        visit "/"
+        fill_in 'update-textarea', :with => "buy this stuff"
+        click_button :'update-button'
+
+        text.must_include "Sorry, it looks like you're a spammer."
+        text.wont_include "buy this stuff"
+      end
     end
   end
 
@@ -137,6 +152,7 @@ describe "update" do
 
       visit "/updates"
       fill_in "text", :with => "So this one time #coolstorybro"
+      check 'not-a-spammer'
       VCR.use_cassette('publish_to_hub') {click_button "Share"}
 
       visit "/updates"


### PR DESCRIPTION
When javascript is enabled, the checkbox will get checked and hidden, so legitimate users won't experience anything different.

If a legitimate user has javascript disabled, they'll see an unchecked checkbox that says "I am not a spammer", and if they check it, their update will be posted.

Any request that does not have this checkbox checked will not result in a posted update.

This might stop spam for a bit, until they figure out they need to send something in this parameter...