### PR TITLE
When a user ID is destroyed but session still exists, site redirects infinitely

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,8 +43,10 @@ class ApplicationController < ActionController::Base
   end
 
   def require_user
-    session[:user_id] = nil
-    redirect_to root_path unless current_user
+    unless current_user
+      sign_out
+      redirect_to root_path
+    end
   end
 
   # Many pages on rstatus are paginated. To keep track of it in all the


### PR DESCRIPTION
- Clear out the user_id in the session hash to prevent infinite redirects
