### PR TITLE
Set up puma as heroku intended

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,8 @@
+workers Integer(ENV['PUMA_WORKERS'] || 3)
+threads Integer(ENV['MIN_THREADS']  || 1), Integer(ENV['MAX_THREADS'] || 1)
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 3000
+environment ENV['RACK_ENV'] || 'development'


### PR DESCRIPTION
According
to https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-serveSet

um hi so, heh, funny story... we aren't actually using puma by default in production on heroku, ooops
