### PR TITLE
Goodbye, airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ end
 gem "haml",                     "~> 3.1.4"
 gem "haml-rails",               "~> 0.3.4"
 gem 'jquery-rails',             "~> 1.0.12"
-gem 'airbrake',                 "~> 3.0.9"
 gem 'bcrypt-ruby',              "~> 3.0.0"
 gem 'omniauth',                 "~> 1.1.0"
 gem "omniauth-twitter",         "~> 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,9 +65,6 @@ GEM
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     addressable (2.3.6)
-    airbrake (3.0.9)
-      activesupport
-      builder
     arel (3.0.3)
     bcrypt-ruby (3.0.1)
     bson (1.9.2)
@@ -291,7 +288,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 3.0.9)
   bcrypt-ruby (~> 3.0.0)
   bson (~> 1.9.0)
   bson_ext (~> 1.9.0)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,3 +1,0 @@
-Airbrake.configure do |config|
-  config.api_key = ENV['AIRBRAKE_API_KEY']
-end


### PR DESCRIPTION
Airbrake doesn't have a free plan on heroku anymore, so let's take it out.
