### PR TITLE
Add rack-timeout gem as recommended by heroku for puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem "exceptional",              "~> 2.0.32"
 gem "newrelic_rpm",             "~> 3.9.6"
 gem "draper",                   "~> 0.11.1"
 gem "open_uri_redirections",    "~> 0.1.4"
-gem "rack-timeout"
+gem "rack-timeout",             "~> 0.1.0"
 
 # background job queue
 gem "delayed_job",              :git => "git://github.com/collectiveidea/delayed_job.git", :tag => "v2.1.4"

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "exceptional",              "~> 2.0.32"
 gem "newrelic_rpm",             "~> 3.9.6"
 gem "draper",                   "~> 0.11.1"
 gem "open_uri_redirections",    "~> 0.1.4"
+gem "rack-timeout"
 
 # background job queue
 gem "delayed_job",              :git => "git://github.com/collectiveidea/delayed_job.git", :tag => "v2.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack-timeout (0.1.0)
     rails (3.2.20)
       actionmailer (= 3.2.20)
       actionpack (= 3.2.20)
@@ -323,6 +324,7 @@ DEPENDENCIES
   puma (~> 2.9.0)
   pygmentize (~> 0.0.3)
   quiet_assets (~> 1.0.0)
+  rack-timeout
   rails (= 3.2.20)
   ratom (~> 0.8.2)
   rdiscount (~> 1.6.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ DEPENDENCIES
   puma (~> 2.9.0)
   pygmentize (~> 0.0.3)
   quiet_assets (~> 1.0.0)
-  rack-timeout
+  rack-timeout (~> 0.1.0)
   rails (= 3.2.20)
   ratom (~> 0.8.2)
   rdiscount (~> 1.6.8)

--- a/config/initializers/timeout.rb
+++ b/config/initializers/timeout.rb
@@ -1,0 +1,4 @@
+# Heroku will time out requests at 30 seconds and show an error to the user, but puma won't know
+# that heroku has terminated the request early, so puma will keep working. This will tell puma to
+# stop and will log a timeout exception.
+Rack::Timeout.timeout = 25  # seconds


### PR DESCRIPTION
So that puma won't get clogged up processing requests that heroku has
timed out.

More details:
https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#