### PR TITLE
Update link to current bundler domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ business is setting up a development environment and making sure all the tests
 pass on your system. Rstat.us is a Ruby on Rails 3.2 application, so it's
 assumed you already have [Ruby](http://www.ruby-lang.org/en/downloads) (1.9.3, 2.0.0
 or 2.1.3 preferred, 1.8.7/1.9.2 compatibility is not guaranteed), rubygems (comes
-with Ruby), and [bundler](http://gembundler.com/) on your machine.
+with Ruby), and [bundler](http://bundler.io/) on your machine.
 If not, each of those links has instructions, and we're willing to help via
 one of the contact methods above if you have issues.
 


### PR DESCRIPTION
The Bundler link currently points to http://gembundler.com, which redirects to http://bundler.io. I changed the link to go directly to http://bundler.io to avoid redirection.
