### PR TITLE
Validate :email in User model using email_validator gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ gem "exceptional",              "~> 2.0.32"
 gem "newrelic_rpm",             "~> 3.9.6"
 gem "draper",                   "~> 0.11.1"
 gem "open_uri_redirections",    "~> 0.1.4"
+gem 'email_validator',          "~> 1.5.0"
 
 # background job queue
 gem "delayed_job",              :git => "git://github.com/collectiveidea/delayed_job.git", :tag => "v2.1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
     database_cleaner (0.6.7)
     draper (0.11.1)
       activesupport (>= 2.3.10)
+    email_validator (1.5.0)
+      activemodel
     equalizer (0.0.9)
     erubis (2.7.0)
     exceptional (2.0.33)
@@ -299,6 +301,7 @@ DEPENDENCIES
   delayed_job!
   delayed_job_mongo_mapper!
   draper (~> 0.11.1)
+  email_validator (~> 1.5.0)
   exceptional (~> 2.0.32)
   fabrication (~> 1.2.0)
   haml (~> 3.1.4)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,7 @@ class User
   # Global preference set via user's profile controlling the state of the Post to Twitter checkbox
   key :always_send_to_twitter, Integer, :default => 1
 
+  validates :email, :email => true
   validate :email_already_confirmed
   validates_uniqueness_of :username,
                           :allow_nil => :true,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,9 @@ class User
   # Global preference set via user's profile controlling the state of the Post to Twitter checkbox
   key :always_send_to_twitter, Integer, :default => 1
 
-  validates :email, :email => true
   validate :email_already_confirmed
+  validates :email, :email => true,
+                          :allow_blank => true
   validates_uniqueness_of :username,
                           :allow_nil => :true,
                           :case_sensitive => false,

--- a/test/acceptance/edit_profile_test.rb
+++ b/test/acceptance/edit_profile_test.rb
@@ -124,7 +124,7 @@ describe "edit profile" do
 
     it "verifies your email if you change it" do
       visit "/users/#{@u.username}/edit"
-      email = "new_email@new_email.com"
+      email = "new_email@newemail.com"
       fill_in "email", :with => email
 
       VCR.use_cassette('update_profile_email') do


### PR DESCRIPTION
#747: I planned to validate `:email` using some regex expression, but as you can see [here](http://www.aidanf.net/posts/validating-emails-in-rails), it's not so easy - so I used [email_validator](https://github.com/balexand/email_validator) gem - Is it OK? :smile: :email: :christmas_tree:
