### PR TITLE
Switch to the mongolab heroku addon

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
     }
   },
   "addons": [
-    "mongohq:sandbox",
+    "mongolab:sandbox",
     "mandrill:starter"
   ]
 }

--- a/config/mongo.yml
+++ b/config/mongo.yml
@@ -13,6 +13,5 @@ test:
 # set these environment variables on your prod server
 production:
   <<: *defaults
-  database: <%= ENV['MONGOHQ_DATABASE'] %>
   uri: <%= ENV['MONGOHQ_URL'] %>
 

--- a/config/mongo.yml
+++ b/config/mongo.yml
@@ -13,5 +13,5 @@ test:
 # set these environment variables on your prod server
 production:
   <<: *defaults
-  uri: <%= ENV['MONGOHQ_URL'] %>
+  uri: <%= ENV['MONGOHQ_URL'] || ENV['MONGOLAB_URI'] || ENV['MONGOSOUP_URL'] || ENV['MONGO_URL'] %>
 


### PR DESCRIPTION
Hiiiiii @wilkie, moar guilt for yooooou!!!! :heart_eyes: 

I was just trying out the heroku button again and it didn't work because Mongohq no longer offers their free sandbox plugin. Mongolab does, so this change gets it working again.

