### PR TITLE
added comments for assets.debug

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -26,5 +26,7 @@ RstatUs::Application.configure do
   config.assets.compress = false
 
   # Expands the lines which load the assets
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
   config.assets.debug = true
 end


### PR DESCRIPTION
Hey guys!,

So after forking, cloning the repo,  I was stuck for 2 days trying to figure out why on earth is the development mode locally taking so long to render views, either initially or at some soon point whilst navigating. After immense researching I found that the fix is by changing config.assets.degug to false. I also found out that using false increases the request time which lead me to do a before and after tail:
before:
![tail_before](https://cloud.githubusercontent.com/assets/11273288/8240821/45ff5b2e-15fd-11e5-9723-796eeb65fcff.png)

after:
![tail_after](https://cloud.githubusercontent.com/assets/11273288/8240828/52243e74-15fd-11e5-9c1a-988fc83178ee.png)

I know the difference isn't humongous but I think it would be worth our while and time saving for people who wish to develop if we didn't alter but just included the comments suggested into this file. 
